### PR TITLE
feat: static Help & FAQ screen in settings (#133)

### DIFF
--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -12,6 +12,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/preferences" options={{ title: 'Food Preferences' }} />
       <Stack.Screen name="settings/privacy" options={{ title: 'Privacy' }} />
       <Stack.Screen name="settings/blocked" options={{ title: 'Blocked & Muted' }} />
+      <Stack.Screen name="settings/help/index" options={{ title: 'Help & FAQ' }} />
     </Stack>
   );
 }

--- a/frontend/app/(tabs)/profile/settings/help/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/help/index.tsx
@@ -1,0 +1,361 @@
+import { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  ScrollView,
+  TextInput,
+  Linking,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { SafeAreaView } from "react-native-safe-area-context";
+import {
+  FAQ_CATEGORIES,
+  FaqCategory,
+  FaqItem,
+  getAllFaqItems,
+} from "../../../../../constants/faq";
+import { colors } from "../../../../../constants/theme";
+
+const SUPPORT_EMAIL = "support@betrfood.com";
+
+type FilteredCategory = FaqCategory & {
+  matchedItems: FaqItem[];
+};
+
+function filterCategories(query: string): FilteredCategory[] {
+  const normalized = query.trim().toLowerCase();
+  if (!normalized) {
+    return FAQ_CATEGORIES.map((category) => ({
+      ...category,
+      matchedItems: category.items,
+    }));
+  }
+  return FAQ_CATEGORIES.map((category) => {
+    const matchedItems = category.items.filter((item) => {
+      const haystack = `${item.question} ${item.answer}`.toLowerCase();
+      return haystack.includes(normalized);
+    });
+    return { ...category, matchedItems };
+  }).filter((category) => category.matchedItems.length > 0);
+}
+
+export default function HelpAndFaqScreen() {
+  const [query, setQuery] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const filtered = useMemo(() => filterCategories(query), [query]);
+  const totalMatches = useMemo(
+    () => filtered.reduce((sum, c) => sum + c.matchedItems.length, 0),
+    [filtered]
+  );
+  const totalItems = useMemo(() => getAllFaqItems().length, []);
+
+  const toggle = (itemId: string) => {
+    setExpandedId((current) => (current === itemId ? null : itemId));
+  };
+
+  const openSupportEmail = () => {
+    Linking.openURL(`mailto:${SUPPORT_EMAIL}`).catch(() => {});
+  };
+
+  const clearSearch = () => setQuery("");
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={["bottom"]}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+      >
+        <View style={styles.heroSection}>
+          <Text style={styles.heroTitle}>How can we help?</Text>
+          <Text style={styles.heroSubtitle}>
+            Browse common questions or search across all topics.
+          </Text>
+        </View>
+
+        <View style={styles.searchWrapper}>
+          <Ionicons
+            name="search"
+            size={18}
+            color={colors.textTertiary}
+            style={styles.searchIcon}
+          />
+          <TextInput
+            style={styles.searchInput}
+            placeholder="Search help articles"
+            placeholderTextColor={colors.textTertiary}
+            value={query}
+            onChangeText={setQuery}
+            autoCorrect={false}
+            returnKeyType="search"
+          />
+          {query.length > 0 && (
+            <Pressable
+              onPress={clearSearch}
+              hitSlop={12}
+              style={styles.clearButton}
+            >
+              <Ionicons
+                name="close-circle"
+                size={18}
+                color={colors.textTertiary}
+              />
+            </Pressable>
+          )}
+        </View>
+
+        {query.length > 0 && (
+          <Text style={styles.resultsCount}>
+            {totalMatches === 0
+              ? "No matches found"
+              : `${totalMatches} of ${totalItems} questions match`}
+          </Text>
+        )}
+
+        {filtered.length === 0 ? (
+          <View style={styles.emptyState}>
+            <Ionicons
+              name="help-circle-outline"
+              size={40}
+              color={colors.textTertiary}
+            />
+            <Text style={styles.emptyTitle}>No results</Text>
+            <Text style={styles.emptyMessage}>
+              Try different keywords, or email us directly and we will get back
+              to you.
+            </Text>
+          </View>
+        ) : (
+          filtered.map((category) => (
+            <View key={category.id} style={styles.categoryBlock}>
+              <View style={styles.categoryHeader}>
+                <View style={styles.categoryIcon}>
+                  <Ionicons
+                    name={category.icon as any}
+                    size={16}
+                    color={colors.primary}
+                  />
+                </View>
+                <Text style={styles.categoryTitle}>{category.title}</Text>
+              </View>
+              <View style={styles.card}>
+                {category.matchedItems.map((item, index) => {
+                  const isLast = index === category.matchedItems.length - 1;
+                  const isOpen = expandedId === item.id;
+                  return (
+                    <View key={item.id}>
+                      <Pressable
+                        style={styles.questionRow}
+                        onPress={() => toggle(item.id)}
+                        accessibilityRole="button"
+                        accessibilityState={{ expanded: isOpen }}
+                      >
+                        <Text style={styles.questionText}>{item.question}</Text>
+                        <Ionicons
+                          name={isOpen ? "chevron-up" : "chevron-down"}
+                          size={18}
+                          color={colors.textTertiary}
+                        />
+                      </Pressable>
+                      {isOpen && (
+                        <View style={styles.answerWrapper}>
+                          <Text style={styles.answerText}>{item.answer}</Text>
+                        </View>
+                      )}
+                      {!isLast && <View style={styles.divider} />}
+                    </View>
+                  );
+                })}
+              </View>
+            </View>
+          ))
+        )}
+
+        <View style={styles.contactCard}>
+          <Text style={styles.contactTitle}>Still need help?</Text>
+          <Text style={styles.contactMessage}>
+            Reach out to our support team and we will get back to you within a
+            few business days.
+          </Text>
+          <Pressable style={styles.contactButton} onPress={openSupportEmail}>
+            <Ionicons name="mail-outline" size={16} color={colors.white} />
+            <Text style={styles.contactButtonText}>Email support</Text>
+          </Pressable>
+        </View>
+
+        <View style={{ height: 32 }} />
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: "#F8FAFC",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+  },
+  heroSection: {
+    paddingBottom: 16,
+  },
+  heroTitle: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: colors.textPrimary,
+    marginBottom: 6,
+  },
+  heroSubtitle: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    lineHeight: 20,
+  },
+  searchWrapper: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: colors.white,
+    borderRadius: 14,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  searchIcon: {
+    marginRight: 8,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: 15,
+    color: colors.textPrimary,
+    paddingVertical: 0,
+  },
+  clearButton: {
+    marginLeft: 8,
+  },
+  resultsCount: {
+    fontSize: 12,
+    color: colors.textSecondary,
+    marginTop: 8,
+    marginLeft: 4,
+  },
+  categoryBlock: {
+    marginTop: 24,
+  },
+  categoryHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+    marginLeft: 4,
+  },
+  categoryIcon: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    backgroundColor: colors.recipeBackground,
+    alignItems: "center",
+    justifyContent: "center",
+    marginRight: 8,
+  },
+  categoryTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: colors.textTertiary,
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+  },
+  card: {
+    backgroundColor: colors.white,
+    borderRadius: 18,
+    overflow: "hidden",
+  },
+  questionRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    gap: 12,
+  },
+  questionText: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "500",
+    color: colors.textPrimary,
+    lineHeight: 20,
+  },
+  answerWrapper: {
+    paddingHorizontal: 16,
+    paddingTop: 2,
+    paddingBottom: 16,
+  },
+  answerText: {
+    fontSize: 14,
+    color: colors.textSecondary,
+    lineHeight: 20,
+  },
+  divider: {
+    height: 1,
+    backgroundColor: "#F1F5F9",
+    marginLeft: 16,
+  },
+  emptyState: {
+    alignItems: "center",
+    paddingVertical: 48,
+    paddingHorizontal: 24,
+  },
+  emptyTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.textPrimary,
+    marginTop: 12,
+    marginBottom: 4,
+  },
+  emptyMessage: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    textAlign: "center",
+    lineHeight: 19,
+  },
+  contactCard: {
+    backgroundColor: colors.white,
+    borderRadius: 18,
+    padding: 20,
+    marginTop: 32,
+    alignItems: "flex-start",
+  },
+  contactTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: colors.textPrimary,
+    marginBottom: 4,
+  },
+  contactMessage: {
+    fontSize: 13,
+    color: colors.textSecondary,
+    lineHeight: 19,
+    marginBottom: 14,
+  },
+  contactButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    backgroundColor: colors.primary,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 12,
+  },
+  contactButtonText: {
+    color: colors.white,
+    fontWeight: "600",
+    fontSize: 14,
+  },
+});

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -105,7 +105,10 @@ export default function Settings() {
             <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
           </Pressable>
           <View style={styles.divider} />
-          <Pressable style={styles.navRow}>
+          <Pressable
+            style={styles.navRow}
+            onPress={() => router.push("/profile/settings/help" as any)}
+          >
             <Text style={styles.navLabel}>Help & Support</Text>
             <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
           </Pressable>

--- a/frontend/constants/faq.ts
+++ b/frontend/constants/faq.ts
@@ -1,0 +1,220 @@
+/**
+ * Static FAQ content for the Help & Support screen.
+ *
+ * Content is shipped in-app and versioned with the app release. Updating any
+ * answer requires a new release. A future CMS integration can replace this
+ * module without changing consumers as long as the exported shape holds.
+ */
+
+export type FaqItem = {
+  id: string;
+  question: string;
+  answer: string;
+};
+
+export type FaqCategory = {
+  id: string;
+  title: string;
+  icon: string; // Ionicons name
+  items: FaqItem[];
+};
+
+export const FAQ_CATEGORIES: FaqCategory[] = [
+  {
+    id: 'account',
+    title: 'Account',
+    icon: 'person-circle-outline',
+    items: [
+      {
+        id: 'account-create',
+        question: 'How do I create a BetrFood account?',
+        answer:
+          'Tap "Sign Up" on the welcome screen and register with your email, Apple, or Google account. You can edit your display name and profile photo any time from the Profile tab.',
+      },
+      {
+        id: 'account-reset-password',
+        question: 'How do I reset my password?',
+        answer:
+          'From the login screen, tap "Forgot password?" and enter the email linked to your account. We will send a password reset link within a few minutes — check your spam folder if you do not see it.',
+      },
+      {
+        id: 'account-change-email',
+        question: 'Can I change the email address on my account?',
+        answer:
+          'Yes. Go to Profile > Settings > Account and tap your email address to update it. You will need to verify the new email before the change takes effect.',
+      },
+      {
+        id: 'account-delete',
+        question: 'How do I delete my account?',
+        answer:
+          'Open Profile > Settings and scroll to the Account section, then tap "Delete Account" and confirm. Deletion is permanent and removes your posts, comments, follows, and saved data.',
+      },
+    ],
+  },
+  {
+    id: 'pantry',
+    title: 'Pantry',
+    icon: 'basket-outline',
+    items: [
+      {
+        id: 'pantry-add',
+        question: 'How do I add an item to my pantry?',
+        answer:
+          'Open the Pantry tab and tap the plus button. You can scan a barcode, search the food database, or add a custom item with your own name and quantity.',
+      },
+      {
+        id: 'pantry-expiry',
+        question: 'Why is an item showing as expired?',
+        answer:
+          'BetrFood tracks expiry dates you enter manually or from barcode scans. If the date looks wrong, tap the item and edit the "Expires on" field to correct it.',
+      },
+      {
+        id: 'pantry-recipes',
+        question: 'How does "Cook with what I have" work?',
+        answer:
+          'We match recipes against the ingredients currently in your pantry, prioritising items nearing expiry. Recipes that require only a couple of extra ingredients are also suggested and labelled accordingly.',
+      },
+    ],
+  },
+  {
+    id: 'posting',
+    title: 'Posting',
+    icon: 'create-outline',
+    items: [
+      {
+        id: 'posting-create',
+        question: 'How do I share a recipe or food photo?',
+        answer:
+          'Tap the plus button in the bottom tab bar, choose a photo or video, then add a caption, tags, and optional recipe steps. Posts are visible to your followers immediately after publishing.',
+      },
+      {
+        id: 'posting-edit',
+        question: 'Can I edit a post after publishing?',
+        answer:
+          'You can edit the caption, tags, and recipe details of any post you own. Open the post, tap the menu icon in the top right, and choose "Edit". The media itself cannot be changed after publishing.',
+      },
+      {
+        id: 'posting-delete',
+        question: 'How do I delete one of my posts?',
+        answer:
+          'Open the post, tap the menu icon, and choose "Delete". Deletion is permanent and will also remove the post\'s likes and comments.',
+      },
+      {
+        id: 'posting-hashtags',
+        question: 'How do hashtags work?',
+        answer:
+          'Hashtags help others discover your post. Type # followed by a keyword in your caption (for example, #mealprep). Tap any hashtag to see trending posts using the same tag.',
+      },
+    ],
+  },
+  {
+    id: 'notifications',
+    title: 'Notifications',
+    icon: 'notifications-outline',
+    items: [
+      {
+        id: 'notifications-disable-all',
+        question: 'How do I turn off all push notifications?',
+        answer:
+          'Go to Profile > Settings > Notifications and toggle "Push notifications" off. This pauses all notification types from BetrFood without affecting your account.',
+      },
+      {
+        id: 'notifications-types',
+        question: 'Can I choose which notifications I get?',
+        answer:
+          'Yes — under Profile > Settings > Notifications you can individually enable or disable likes, comments, follows, mentions, and recipe reminders.',
+      },
+      {
+        id: 'notifications-not-arriving',
+        question: 'Why am I not receiving notifications?',
+        answer:
+          'Check that notifications are enabled both in BetrFood (Settings > Notifications) and in your device\'s system settings for BetrFood. Do Not Disturb and focus modes can also silence them.',
+      },
+    ],
+  },
+  {
+    id: 'privacy',
+    title: 'Privacy',
+    icon: 'lock-closed-outline',
+    items: [
+      {
+        id: 'privacy-profile',
+        question: 'How do I make my profile private?',
+        answer:
+          'Go to Profile > Settings > Privacy and turn off "Public Profile". Only accounts you approve as followers will be able to see your posts and activity.',
+      },
+      {
+        id: 'privacy-block',
+        question: 'What happens when I block someone?',
+        answer:
+          'Blocked users cannot see your profile, posts, or comments, and cannot follow or message you. They are not notified that you blocked them.',
+      },
+      {
+        id: 'privacy-data',
+        question: 'What data does BetrFood collect about me?',
+        answer:
+          'We collect the content you create, your pantry and recipe activity, and basic device diagnostics. Full details are in our Privacy Policy, linked from Settings > Legal.',
+      },
+    ],
+  },
+  {
+    id: 'recipes',
+    title: 'Recipes',
+    icon: 'restaurant-outline',
+    items: [
+      {
+        id: 'recipes-save',
+        question: 'How do I save a recipe for later?',
+        answer:
+          'Tap the bookmark icon on any recipe to save it. Saved recipes appear in Profile > Collections, where you can organise them into folders such as "Weeknight" or "Desserts".',
+      },
+      {
+        id: 'recipes-scale',
+        question: 'Can I scale a recipe up or down?',
+        answer:
+          'Open the recipe and tap the serving count near the top. Adjust it to the number of servings you need — ingredient quantities update automatically.',
+      },
+      {
+        id: 'recipes-missing-steps',
+        question: 'A recipe I posted is missing steps after editing — what happened?',
+        answer:
+          'Recipe steps are saved separately from the caption. If steps appear blank after an edit, reopen the editor, re-add the steps, and save again. If the problem persists, contact support.',
+      },
+    ],
+  },
+  {
+    id: 'troubleshooting',
+    title: 'Troubleshooting',
+    icon: 'construct-outline',
+    items: [
+      {
+        id: 'trouble-crash',
+        question: 'The app keeps crashing — what should I try first?',
+        answer:
+          'Force-quit BetrFood and reopen it, then make sure you are on the latest version from the App Store or Play Store. If it still crashes, restart your device and try again.',
+      },
+      {
+        id: 'trouble-upload',
+        question: 'My photo or video upload keeps failing.',
+        answer:
+          'Uploads need a stable connection. Switch between Wi-Fi and cellular, make sure the file is under 100MB, and retry. If the issue continues, try uploading a smaller version of the media.',
+      },
+      {
+        id: 'trouble-contact',
+        question: 'Something else is wrong — how do I contact support?',
+        answer:
+          'Email support@betrfood.com with a short description of the issue and, if possible, a screenshot. Please include your app version (shown in Settings > App Information) so we can help faster.',
+      },
+    ],
+  },
+];
+
+export function getAllFaqItems(): Array<FaqItem & { categoryId: string; categoryTitle: string }> {
+  return FAQ_CATEGORIES.flatMap((category) =>
+    category.items.map((item) => ({
+      ...item,
+      categoryId: category.id,
+      categoryTitle: category.title,
+    }))
+  );
+}


### PR DESCRIPTION
## Summary

Adds an in-app **Help & Support** destination with a searchable, categorised FAQ, reachable from `Profile > Settings > Help & Support`.

- `frontend/constants/faq.ts` — typed `FAQ_CATEGORIES` array with ~20 Q&A pairs across Account, Pantry, Posting, Notifications, Privacy, Recipes, and Troubleshooting. Answers are 1-3 sentences of realistic copy.
- `frontend/app/(tabs)/profile/settings/help/index.tsx` — FAQ screen with:
  - Top search input that filters across every question and answer (case-insensitive substring match).
  - Categorised accordion layout; tapping a question expands its answer inline. Only one question is expanded at a time.
  - "Still need help?" card with a `mailto:support@betrfood.com` escape hatch.
- `frontend/app/(tabs)/profile/settings/index.tsx` — wires the existing "Help & Support" row to push `/profile/settings/help`.
- `frontend/app/(tabs)/profile/_layout.tsx` — registers `settings/help/index` with title "Help & FAQ".

## Scope notes

The **"remotely updatable without app release"** acceptance criterion from #133 is intentionally **deferred** — no CMS infrastructure exists yet. This PR ships static content bundled with the app; updating any answer requires a new release. Future CMS integration can be tracked in a follow-up issue.

The module shape (`FAQ_CATEGORIES: FaqCategory[]`) is deliberately consumer-facing so a future remote source can swap the constants module without touching the screen.

## Test plan

- [ ] Open `Profile > Settings` and tap **Help & Support** — new FAQ screen pushes onto the stack with header title "Help & FAQ".
- [ ] Tap a question — answer expands inline; tap again to collapse.
- [ ] Tap a second question — first collapses, second opens (single-open behaviour).
- [ ] Type in the search box — categories and questions filter live; "N of M questions match" count updates.
- [ ] Search for nonsense text (e.g. `zzzzz`) — empty state with "No results" renders.
- [ ] Clear search via the `×` button — all categories return.
- [ ] Tap **Email support** in the "Still need help?" card — system mail composer opens to `support@betrfood.com`.

Refs #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)