### PR TITLE
feat: add grid/list feed layout preference (#124)

### DIFF
--- a/frontend/app/(tabs)/feeds/user-profile.tsx
+++ b/frontend/app/(tabs)/feeds/user-profile.tsx
@@ -4,6 +4,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useState, useCallback, useContext, useEffect } from 'react';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { AuthContext } from '../../../context/AuthenticationContext';
+import { useFeedLayout } from '../../../context/FeedLayoutContext';
 import VideoThumbnailView from '../../../components/VideoThumbnail';
 import {
   fetchUserProfile,
@@ -31,6 +32,7 @@ import { colors } from '../../../constants/theme';
 const { width } = Dimensions.get('window');
 const GRID_GAP = 2;
 const ITEM_SIZE = (width - GRID_GAP * 2) / 3;
+const LIST_ITEM_HEIGHT = Math.round(width * 0.9);
 
 function formatCount(count: number): string {
   if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(count % 1_000_000 === 0 ? 0 : 1)}M`;
@@ -42,6 +44,7 @@ export default function UserProfileScreen() {
   const router = useRouter();
   const { userId } = useLocalSearchParams<{ userId: string }>();
   const { user: currentUser } = useContext(AuthContext);
+  const { layout: feedLayout } = useFeedLayout();
 
   const [profile, setProfile] = useState<UserProfile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -432,26 +435,49 @@ export default function UserProfileScreen() {
       <View style={styles.container}>
         {(!isPrivate || isFollowing) ? (
           <FlatList
+            key={feedLayout}
             data={userPosts}
             keyExtractor={(item) => item.id}
-            numColumns={3}
+            numColumns={feedLayout === 'grid' ? 3 : 1}
             ListHeaderComponent={renderProfileHeader}
-            renderItem={({ item }) => (
-              <View>
-                {item.mediaType === 'video' ? (
-                  <VideoThumbnailView
-                    videoUri={getImageUrl(item.imagePath)}
-                    style={styles.gridItem}
-                  />
-                ) : (
-                  <Image
-                    source={{ uri: getImageUrl(item.imagePath) }}
-                    style={styles.gridItem}
-                    accessibilityLabel={item.caption || 'Post image'}
-                  />
-                )}
-              </View>
-            )}
+            renderItem={({ item }) =>
+              feedLayout === 'grid' ? (
+                <View>
+                  {item.mediaType === 'video' ? (
+                    <VideoThumbnailView
+                      videoUri={getImageUrl(item.imagePath)}
+                      style={styles.gridItem}
+                    />
+                  ) : (
+                    <Image
+                      source={{ uri: getImageUrl(item.imagePath) }}
+                      style={styles.gridItem}
+                      accessibilityLabel={item.caption || 'Post image'}
+                    />
+                  )}
+                </View>
+              ) : (
+                <View style={styles.listItem}>
+                  {item.mediaType === 'video' ? (
+                    <VideoThumbnailView
+                      videoUri={getImageUrl(item.imagePath)}
+                      style={styles.listMedia}
+                    />
+                  ) : (
+                    <Image
+                      source={{ uri: getImageUrl(item.imagePath) }}
+                      style={styles.listMedia}
+                      accessibilityLabel={item.caption || 'Post image'}
+                    />
+                  )}
+                  {item.caption ? (
+                    <Text style={styles.listCaption} numberOfLines={2}>
+                      {item.caption}
+                    </Text>
+                  ) : null}
+                </View>
+              )
+            }
             showsVerticalScrollIndicator={false}
             ListEmptyComponent={
               <View style={styles.emptyGrid}>
@@ -661,6 +687,28 @@ const styles = StyleSheet.create({
     backgroundColor: colors.borderLight,
     borderRadius: 8,
     overflow: 'hidden',
+  },
+
+  /* Post list */
+  listItem: {
+    width: '100%',
+    paddingHorizontal: 12,
+    paddingTop: 8,
+    paddingBottom: 16,
+    backgroundColor: colors.backgroundPrimary,
+  },
+  listMedia: {
+    width: '100%',
+    height: LIST_ITEM_HEIGHT,
+    backgroundColor: colors.borderLight,
+    borderRadius: 12,
+    overflow: 'hidden',
+  },
+  listCaption: {
+    marginTop: 10,
+    fontSize: 14,
+    lineHeight: 20,
+    color: colors.textPrimary,
   },
 
   /* Empty state */

--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -14,6 +14,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/notifications" options={{ title: 'Notifications' }} />
       <Stack.Screen name="settings/blocked" options={{ title: 'Blocked & Muted' }} />
       <Stack.Screen name="settings/help/index" options={{ title: 'Help & FAQ' }} />
+      <Stack.Screen name="settings/appearance" options={{ title: 'Appearance' }} />
     </Stack>
   );
 }

--- a/frontend/app/(tabs)/profile/settings/appearance.tsx
+++ b/frontend/app/(tabs)/profile/settings/appearance.tsx
@@ -1,0 +1,154 @@
+import { Ionicons } from "@expo/vector-icons";
+import { Pressable, ScrollView, StyleSheet, Text, View } from "react-native";
+import { FeedLayout, useFeedLayout } from "../../../../context/FeedLayoutContext";
+
+interface LayoutOption {
+  value: FeedLayout;
+  title: string;
+  description: string;
+  icon: keyof typeof Ionicons.glyphMap;
+}
+
+const OPTIONS: LayoutOption[] = [
+  {
+    value: "grid",
+    title: "Grid",
+    description: "Compact 3-column grid. See more posts at a glance.",
+    icon: "grid-outline",
+  },
+  {
+    value: "list",
+    title: "List",
+    description: "Single column with larger previews and captions.",
+    icon: "list-outline",
+  },
+];
+
+export default function AppearanceSettings() {
+  const { layout, setLayout } = useFeedLayout();
+
+  return (
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+      <Text style={styles.sectionHeader}>FEED LAYOUT</Text>
+      <Text style={styles.sectionDescription}>
+        Choose how posts appear on profile feeds. Changes apply instantly.
+      </Text>
+
+      <View style={styles.optionsGroup}>
+        {OPTIONS.map((option) => {
+          const selected = layout === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              onPress={() => setLayout(option.value)}
+              style={[styles.optionCard, selected && styles.optionCardSelected]}
+              accessibilityRole="radio"
+              accessibilityState={{ selected }}
+              accessibilityLabel={`${option.title} layout`}
+            >
+              <View style={[styles.iconBubble, selected && styles.iconBubbleSelected]}>
+                <Ionicons
+                  name={option.icon}
+                  size={22}
+                  color={selected ? "#22C55E" : "#64748B"}
+                />
+              </View>
+              <View style={styles.optionText}>
+                <Text style={styles.optionTitle}>{option.title}</Text>
+                <Text style={styles.optionDescription}>{option.description}</Text>
+              </View>
+              <View style={[styles.radio, selected && styles.radioSelected]}>
+                {selected && <View style={styles.radioDot} />}
+              </View>
+            </Pressable>
+          );
+        })}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F8FAFC",
+  },
+  content: {
+    padding: 20,
+  },
+  sectionHeader: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#94A3B8",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    marginBottom: 6,
+    marginLeft: 4,
+  },
+  sectionDescription: {
+    fontSize: 13,
+    color: "#64748B",
+    marginBottom: 16,
+    marginLeft: 4,
+    lineHeight: 18,
+  },
+  optionsGroup: {
+    gap: 12,
+  },
+  optionCard: {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: "#FFFFFF",
+    borderRadius: 16,
+    padding: 16,
+    borderWidth: 2,
+    borderColor: "transparent",
+    gap: 14,
+  },
+  optionCardSelected: {
+    borderColor: "#22C55E",
+  },
+  iconBubble: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "#F1F5F9",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  iconBubbleSelected: {
+    backgroundColor: "#F0FDF4",
+  },
+  optionText: {
+    flex: 1,
+  },
+  optionTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#0F172A",
+    marginBottom: 2,
+  },
+  optionDescription: {
+    fontSize: 13,
+    color: "#64748B",
+    lineHeight: 18,
+  },
+  radio: {
+    width: 22,
+    height: 22,
+    borderRadius: 11,
+    borderWidth: 2,
+    borderColor: "#CBD5E1",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  radioSelected: {
+    borderColor: "#22C55E",
+  },
+  radioDot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+    backgroundColor: "#22C55E",
+  },
+});

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -98,6 +98,18 @@ export default function Settings() {
           </Pressable>
         </View>
 
+        {/* APPEARANCE */}
+        <Text style={styles.sectionHeader}>APPEARANCE</Text>
+        <View style={styles.card}>
+          <Pressable
+            style={styles.navRow}
+            onPress={() => router.push("/profile/settings/appearance" as any)}
+          >
+            <Text style={styles.navLabel}>Feed Layout</Text>
+            <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
+          </Pressable>
+        </View>
+
         {/* LEGAL */}
         <Text style={styles.sectionHeader}>LEGAL</Text>
         <View style={styles.card}>

--- a/frontend/context/FeedLayoutContext.tsx
+++ b/frontend/context/FeedLayoutContext.tsx
@@ -1,0 +1,58 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { createContext, ReactNode, useCallback, useContext, useEffect, useState } from "react";
+
+export type FeedLayout = "grid" | "list";
+
+const STORAGE_KEY = "@betrfood/feedLayout";
+const DEFAULT_LAYOUT: FeedLayout = "grid";
+
+interface FeedLayoutContextType {
+  layout: FeedLayout;
+  setLayout: (value: FeedLayout) => Promise<void>;
+  ready: boolean;
+}
+
+const FeedLayoutContext = createContext<FeedLayoutContextType | undefined>(undefined);
+
+export function FeedLayoutProvider({ children }: { children: ReactNode }) {
+  const [layout, setLayoutState] = useState<FeedLayout>(DEFAULT_LAYOUT);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        if (stored === "grid" || stored === "list") {
+          setLayoutState(stored);
+        }
+      } catch {
+        // Fall back to default.
+      } finally {
+        setReady(true);
+      }
+    })();
+  }, []);
+
+  const setLayout = useCallback(async (value: FeedLayout) => {
+    setLayoutState(value);
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, value);
+    } catch {
+      // Ignore persistence failure; in-memory state is already updated.
+    }
+  }, []);
+
+  return (
+    <FeedLayoutContext.Provider value={{ layout, setLayout, ready }}>
+      {children}
+    </FeedLayoutContext.Provider>
+  );
+}
+
+export function useFeedLayout() {
+  const ctx = useContext(FeedLayoutContext);
+  if (!ctx) {
+    throw new Error("useFeedLayout must be used within FeedLayoutProvider");
+  }
+  return ctx;
+}

--- a/frontend/context/Providers.tsx
+++ b/frontend/context/Providers.tsx
@@ -4,15 +4,18 @@ import { AuthProvider } from "./AuthenticationContext";
 import { PantryProvider } from "./PantryContext";
 import { ActionSheetProvider } from "@expo/react-native-action-sheet";
 import { PreferencesProvider } from "./PreferencesContext";
+import { FeedLayoutProvider } from "./FeedLayoutContext";
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <AuthProvider>
       <ActionSheetProvider>
         <PreferencesProvider>
-          <CollectionsProvider>
-            <PantryProvider>{children}</PantryProvider>
-          </CollectionsProvider>
+          <FeedLayoutProvider>
+            <CollectionsProvider>
+              <PantryProvider>{children}</PantryProvider>
+            </CollectionsProvider>
+          </FeedLayoutProvider>
         </PreferencesProvider>
       </ActionSheetProvider>
     </AuthProvider>


### PR DESCRIPTION
## Summary

Closes #124.

Adds an **Appearance** section to profile settings with a grid/list selector for the profile feed. Preference persists to AsyncStorage under `@betrfood/feedLayout` and applies immediately without reload.

- New `FeedLayoutContext` wraps `Providers`, hydrates from AsyncStorage on mount, defaults to `"grid"`.
- New `frontend/app/(tabs)/profile/settings/appearance.tsx` renders two radio cards (grid / list).
- Added **Appearance > Feed Layout** link in `settings/index.tsx` and registered the screen in the profile stack.
- `frontend/app/(tabs)/feeds/user-profile.tsx` now reads the preference and renders either the existing 3-column grid or a single-column list (larger media + caption).

No backend changes.

## Test plan

- [ ] Open profile settings: a new **Appearance** section shows a **Feed Layout** row.
- [ ] Tapping it opens the Appearance screen with Grid (default) selected.
- [ ] Selecting **List** switches the radio and persists the choice.
- [ ] Navigate to any other user's profile: posts render as a single-column list with large previews and captions.
- [ ] Switch back to **Grid**: the same profile feed re-renders as the 3-column grid immediately (no reload).
- [ ] Kill and reopen the app: last-selected layout is restored.
- [ ] TypeScript type-check introduces no new errors (`npx tsc --noEmit` diff-clean for new/modified files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)