### PR TITLE
feat: global in-app notifications toggle (#113)

### DIFF
--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -10,10 +10,11 @@ const { requireAuth } = require('../middleware/auth');
  */
 router.post('/check-expiring-all', async (req, res) => {
   try {
-    // Get all users who have expiration notifications enabled
+    // Get all users who have expiration notifications enabled AND global
+    // in-app notifications enabled (issue #113).
     const { data: users, error: usersError } = await supabase
       .from('user_preferences')
-      .select('user_id, expiring_items_threshold')
+      .select('user_id, expiring_items_threshold, notifications_enabled')
       .eq('expiration_notifications_enabled', true);
 
     if (usersError) throw usersError;
@@ -22,6 +23,8 @@ router.post('/check-expiring-all', async (req, res) => {
     let totalCreated = 0;
 
     for (const user of users || []) {
+      // Short-circuit when the user has globally disabled notifications.
+      if (user.notifications_enabled === false) continue;
       const { checked, created } = await checkExpiringItemsForUser(
         user.user_id,
         user.expiring_items_threshold || 7
@@ -53,13 +56,18 @@ router.post('/check-expiring', async (req, res) => {
     // Fetch user preferences
     const { data: prefs, error: prefsError } = await supabase
       .from('user_preferences')
-      .select('expiring_items_threshold, expiration_notifications_enabled')
+      .select('expiring_items_threshold, expiration_notifications_enabled, notifications_enabled')
       .eq('user_id', req.userId)
       .single();
 
     if (prefsError && prefsError.code !== 'PGRST116') throw prefsError;
 
     console.log('[EXPIRING-CHECK] userId:', req.userId, 'prefs:', JSON.stringify(prefs));
+
+    // Short-circuit when the user has globally disabled notifications (#113).
+    if (prefs?.notifications_enabled === false) {
+      return res.json({ checked: 0, created: 0, skipped: true });
+    }
 
     const threshold = prefs?.expiring_items_threshold || 7;
     const { checked, created } = await checkExpiringItemsForUser(req.userId, threshold);

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -25,7 +25,8 @@ router.get('/', requireAuth, async (req, res) => {
         cookingSkill: 'beginner',
         maxCookTime: null,
         expiringItemsThreshold: 7,
-        expirationNotificationsEnabled: false
+        expirationNotificationsEnabled: false,
+        notificationsEnabled: true
       });
     }
 
@@ -44,7 +45,8 @@ router.get('/', requireAuth, async (req, res) => {
       cookingSkill: data.cooking_skill || 'beginner',
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
-      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false
+      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
+      notificationsEnabled: data.notifications_enabled ?? true
     });
   } catch (error) {
     console.error('Error fetching preferences:', error);
@@ -145,6 +147,14 @@ router.put('/', requireAuth, async (req, res) => {
       updates.expiration_notifications_enabled = expirationNotificationsEnabled;
     }
 
+    const { notificationsEnabled } = req.body;
+    if (notificationsEnabled !== undefined) {
+      if (typeof notificationsEnabled !== 'boolean') {
+        return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+      }
+      updates.notifications_enabled = notificationsEnabled;
+    }
+
     const { data, error } = await supabase
       .from('user_preferences')
       .upsert(updates, { onConflict: 'user_id' })
@@ -169,10 +179,64 @@ router.put('/', requireAuth, async (req, res) => {
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
       expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
+      notificationsEnabled: data.notifications_enabled ?? true,
     });
   } catch (error) {
     console.error('Error updating preferences:', error);
     res.status(500).json({ error: 'Failed to update preferences.' });
+  }
+});
+
+// GET /api/preferences/notifications - Get notification preferences
+router.get('/notifications', requireAuth, async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('notifications_enabled')
+      .eq('user_id', req.userId)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    res.json({
+      notificationsEnabled: data?.notifications_enabled ?? true,
+    });
+  } catch (error) {
+    console.error('Error fetching notification preferences:', error);
+    res.status(500).json({ error: 'Failed to fetch notification preferences.' });
+  }
+});
+
+// PATCH /api/preferences/notifications - Update notification preferences
+router.patch('/notifications', requireAuth, async (req, res) => {
+  try {
+    const { notificationsEnabled } = req.body;
+
+    if (typeof notificationsEnabled !== 'boolean') {
+      return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .upsert(
+        {
+          user_id: req.userId,
+          notifications_enabled: notificationsEnabled,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id' }
+      )
+      .select('notifications_enabled')
+      .single();
+
+    if (error) throw error;
+
+    res.json({
+      notificationsEnabled: data.notifications_enabled ?? true,
+    });
+  } catch (error) {
+    console.error('Error updating notification preferences:', error);
+    res.status(500).json({ error: 'Failed to update notification preferences.' });
   }
 });
 

--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -11,6 +11,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/index" options={{ title: 'Settings' }} />
       <Stack.Screen name="settings/preferences" options={{ title: 'Food Preferences' }} />
       <Stack.Screen name="settings/privacy" options={{ title: 'Privacy' }} />
+      <Stack.Screen name="settings/notifications" options={{ title: 'Notifications' }} />
       <Stack.Screen name="settings/blocked" options={{ title: 'Blocked & Muted' }} />
     </Stack>
   );

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -86,6 +86,18 @@ export default function Settings() {
           </View>
         </View>
 
+        {/* NOTIFICATIONS */}
+        <Text style={styles.sectionHeader}>NOTIFICATIONS</Text>
+        <View style={styles.card}>
+          <Pressable
+            style={styles.navRow}
+            onPress={() => router.push("/profile/settings/notifications" as any)}
+          >
+            <Text style={styles.navLabel}>Push Notifications</Text>
+            <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
+          </Pressable>
+        </View>
+
         {/* LEGAL */}
         <Text style={styles.sectionHeader}>LEGAL</Text>
         <View style={styles.card}>

--- a/frontend/app/(tabs)/profile/settings/notifications.tsx
+++ b/frontend/app/(tabs)/profile/settings/notifications.tsx
@@ -1,0 +1,143 @@
+import {
+  View,
+  Text,
+  StyleSheet,
+  Switch,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useEffect, useState } from "react";
+import {
+  fetchNotificationPreferences,
+  updateNotificationPreferences,
+} from "../../../../services/api";
+import { usePreferences } from "../../../../context/PreferencesContext";
+
+export default function NotificationSettings() {
+  const { preferences, loading: contextLoading } = usePreferences();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const { notificationsEnabled } = await fetchNotificationPreferences();
+        if (active) setEnabled(notificationsEnabled);
+      } catch {
+        // Fall back to context value when the dedicated endpoint fails
+        if (active && preferences) {
+          setEnabled(preferences.notificationsEnabled ?? true);
+        } else if (active) {
+          setEnabled(true);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [preferences]);
+
+  const handleToggle = async (value: boolean) => {
+    const previous = enabled;
+    setEnabled(value);
+    setSaving(true);
+    try {
+      const result = await updateNotificationPreferences({
+        notificationsEnabled: value,
+      });
+      setEnabled(result.notificationsEnabled);
+    } catch {
+      setEnabled(previous);
+      Alert.alert("Error", "Failed to update notification settings. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || contextLoading || enabled === null) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <ActivityIndicator size="large" color="#007AFF" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <View style={styles.row}>
+          <View style={styles.rowInfo}>
+            <Text style={styles.rowTitle}>Push Notifications</Text>
+            <Text style={styles.rowDescription}>
+              {enabled
+                ? "You'll receive in-app notifications about your activity."
+                : "In-app notifications are paused. You won't receive any new alerts."}
+            </Text>
+          </View>
+          <Switch
+            value={enabled}
+            onValueChange={handleToggle}
+            disabled={saving}
+            trackColor={{ false: "#ccc", true: "#007AFF" }}
+            thumbColor="#fff"
+            accessibilityLabel="Toggle global notifications"
+            accessibilityRole="switch"
+          />
+        </View>
+      </View>
+
+      <Text style={styles.footnote}>
+        This is a master switch for all in-app notifications. Individual
+        notification types can be configured separately when those controls are
+        added.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    padding: 20,
+  },
+  centered: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  section: {
+    borderTopWidth: 1,
+    borderTopColor: "#eee",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+  },
+  rowInfo: {
+    flex: 1,
+    marginRight: 16,
+  },
+  rowTitle: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  rowDescription: {
+    fontSize: 13,
+    color: "#888",
+    marginTop: 3,
+  },
+  footnote: {
+    marginTop: 20,
+    fontSize: 12,
+    color: "#888",
+    lineHeight: 18,
+  },
+});

--- a/frontend/context/PreferencesContext.tsx
+++ b/frontend/context/PreferencesContext.tsx
@@ -9,6 +9,7 @@ export interface Preferences {
   cuisines: string[];
   expiringItemsThreshold: number;
   expirationNotificationsEnabled: boolean;
+  notificationsEnabled: boolean;
   profileVisibility: "public" | "private";
   dietaryInfoVisible: boolean;
 }
@@ -31,6 +32,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   cuisines: [],
   expiringItemsThreshold: 7,
   expirationNotificationsEnabled: false,
+  notificationsEnabled: true,
   profileVisibility: "public",
   dietaryInfoVisible: true,
 };
@@ -55,6 +57,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         cuisines: prefs.cuisines || [],
         expiringItemsThreshold: prefs.expiringItemsThreshold ?? 7,
         expirationNotificationsEnabled: prefs.expirationNotificationsEnabled ?? false,
+        notificationsEnabled: prefs.notificationsEnabled ?? true,
         profileVisibility: prefs.profileVisibility || "public",
         dietaryInfoVisible: prefs.dietaryInfoVisible ?? true,
       });

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -38,7 +38,7 @@ export type { FollowRequest } from './follows';
 export { savePost, unsavePost, checkSaveStatus, fetchCollections, createCollection, deleteCollection, addPostToCollection, removePostFromCollection, fetchCollectionPosts } from './collections';
 export { reportContent } from './reports';
 export { checkBlockStatus, checkMuteStatus, blockUser, unblockUser, muteUser, unmuteUser, fetchBlockedUsers, fetchMutedUsers } from './blocks';
-export { fetchPreferences, updatePreferences } from './preferences';
+export { fetchPreferences, updatePreferences, fetchNotificationPreferences, updateNotificationPreferences } from './preferences';
 export { fetchNotifications, markNotificationRead, markAllNotificationsRead, clearAllNotifications, fetchUnreadNotificationCount, checkExpiringItems } from './notifications';
 export type { Notification } from './notifications';
 export { fetchAdminUsers, updateUserRole, fetchAdminStats, updateUserVerification } from './admin';

--- a/frontend/services/api/preferences.ts
+++ b/frontend/services/api/preferences.ts
@@ -19,6 +19,7 @@ export async function updatePreferences(prefs: {
   dietaryInfoVisible?: boolean;
   expiringItemsThreshold?: number;
   expirationNotificationsEnabled?: boolean;
+  notificationsEnabled?: boolean;
 }) {
   const response = await fetch(`${API_BASE_URL}/api/preferences`, {
     method: 'PUT',
@@ -28,6 +29,32 @@ export async function updatePreferences(prefs: {
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.error || 'Failed to update preferences');
+  }
+  return response.json();
+}
+
+export async function fetchNotificationPreferences(): Promise<{ notificationsEnabled: boolean }> {
+  const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
+    headers: await authHeaders(),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch notification preferences');
+  }
+  return response.json();
+}
+
+export async function updateNotificationPreferences(
+  prefs: { notificationsEnabled: boolean }
+): Promise<{ notificationsEnabled: boolean }> {
+  const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
+    body: JSON.stringify(prefs),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to update notification preferences');
   }
   return response.json();
 }

--- a/supabase/migrations/20260423000000_add_notifications_enabled.sql
+++ b/supabase/migrations/20260423000000_add_notifications_enabled.sql
@@ -1,0 +1,6 @@
+-- Add notifications_enabled column to user_preferences
+-- Global in-app notification toggle. When false, the notification dispatch
+-- path short-circuits and no new notification records are created for the
+-- user. See GitHub issue #113.
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS notifications_enabled BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary

Closes #113.

Adds a master switch in **Profile > Settings > Notifications** that disables all in-app notifications for the user. When off, the notification dispatch path short-circuits and no new notification records are created. Scope is limited to the existing in-app notifications subsystem — no push infrastructure (Expo Notifications / FCM / APNs) is introduced.

- **Migration** `supabase/migrations/20260423000000_add_notifications_enabled.sql`: adds `notifications_enabled BOOLEAN NOT NULL DEFAULT true` to `user_preferences`.
- **Backend** `backend/src/routes/preferences.js`: new `GET` and `PATCH /api/preferences/notifications` endpoints; field included in the main preferences payload.
- **Backend** `backend/src/routes/notifications.js`: both the per-user `/check-expiring` route and the cron `/check-expiring-all` path skip dispatch when `notifications_enabled = false`.
- **Frontend**: new `notifications.tsx` screen with a single persisted switch, linked from the settings index as a new `NOTIFICATIONS` section; context and API client extended to carry the new field.

## Test plan

- [ ] Run the migration against a dev Supabase instance and verify the column exists with default `true` for existing rows.
- [ ] `GET /api/preferences/notifications` returns `{ notificationsEnabled: true }` for a new user.
- [ ] `PATCH /api/preferences/notifications` with `{ "notificationsEnabled": false }` persists and returns the new value.
- [ ] `PATCH` with a non-boolean body returns a 400.
- [ ] After toggling off, `POST /api/notifications/check-expiring` returns `{ checked: 0, created: 0, skipped: true }` and no new rows land in `notifications`.
- [ ] After toggling off, the cron `POST /api/notifications/check-expiring-all` skips the user (no new rows).
- [ ] Toggling back on resumes dispatch on the next check.
- [ ] In the app, Profile > Settings shows a **NOTIFICATIONS** row leading to the new screen; the switch reflects and persists the server value across app restarts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)