### PR TITLE
feat(settings): Reset Recommendations (Data & Storage) — closes #128

### DIFF
--- a/backend/src/routes/users.js
+++ b/backend/src/routes/users.js
@@ -4,6 +4,45 @@ const { requireAuth } = require("../middleware/auth");
 
 const router = express.Router();
 
+// POST /api/users/me/reset-recommendations — clear recommendation-signal data for the current user
+// Deletes: post_impressions, post_negative_feedback, and user_preference_vectors rows for this user.
+// After reset the For You feed falls back to non-personalized content (cold-start path in
+// getUserPreferenceVector rebuilds a neutral vector on next fetch).
+router.post("/me/reset-recommendations", requireAuth, async (req, res) => {
+  const userId = req.userId;
+  try {
+    const { count: impressionsCount, error: impErr } = await supabase
+      .from("post_impressions")
+      .delete({ count: "exact" })
+      .eq("user_id", userId);
+    if (impErr) throw impErr;
+
+    const { count: negativeCount, error: negErr } = await supabase
+      .from("post_negative_feedback")
+      .delete({ count: "exact" })
+      .eq("user_id", userId);
+    if (negErr) throw negErr;
+
+    const { count: vectorCount, error: vecErr } = await supabase
+      .from("user_preference_vectors")
+      .delete({ count: "exact" })
+      .eq("user_id", userId);
+    if (vecErr) throw vecErr;
+
+    res.json({
+      message: "Recommendations reset.",
+      deleted: {
+        impressions: impressionsCount || 0,
+        negativeFeedback: negativeCount || 0,
+        preferenceVector: vectorCount || 0,
+      },
+    });
+  } catch (error) {
+    console.error("Error resetting recommendations:", error);
+    res.status(500).json({ error: "Failed to reset recommendations." });
+  }
+});
+
 // DELETE /api/users/me — permanently delete the current user's account and all data
 router.delete("/me", requireAuth, async (req, res) => {
   const userId = req.userId;

--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -16,6 +16,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/help/index" options={{ title: 'Help & FAQ' }} />
       <Stack.Screen name="settings/appearance" options={{ title: 'Appearance' }} />
       <Stack.Screen name="settings/linked-accounts" options={{ title: 'Linked Accounts' }} />
+      <Stack.Screen name="settings/data-storage" options={{ title: 'Data & Storage' }} />
     </Stack>
   );
 }

--- a/frontend/app/(tabs)/profile/settings/data-storage.tsx
+++ b/frontend/app/(tabs)/profile/settings/data-storage.tsx
@@ -1,0 +1,242 @@
+import { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  Pressable,
+  Alert,
+  ScrollView,
+  Modal,
+  ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { resetRecommendations } from "../../../../services/api";
+
+export default function DataStorageScreen() {
+  const [confirmVisible, setConfirmVisible] = useState(false);
+  const [resetting, setResetting] = useState(false);
+
+  const handleConfirmReset = async () => {
+    setResetting(true);
+    try {
+      const result = await resetRecommendations();
+      setConfirmVisible(false);
+      const { impressions, negativeFeedback, preferenceVector } = result.deleted;
+      const total = impressions + negativeFeedback + preferenceVector;
+      Alert.alert(
+        "Recommendations reset",
+        total === 0
+          ? "Your recommendation signals were already clear. Pull to refresh For You to see non-personalized content."
+          : `Cleared ${impressions} view record${impressions === 1 ? "" : "s"}, ${negativeFeedback} "not interested" entr${negativeFeedback === 1 ? "y" : "ies"}, and your learned preferences. Pull to refresh For You to see non-personalized content.`
+      );
+    } catch (err) {
+      setConfirmVisible(false);
+      const message = err instanceof Error ? err.message : "Please try again.";
+      Alert.alert("Reset failed", message);
+    } finally {
+      setResetting(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <ScrollView
+        style={styles.scrollView}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+      >
+        <Text style={styles.sectionHeader}>RECOMMENDATIONS</Text>
+        <View style={styles.card}>
+          <View style={styles.infoBlock}>
+            <Text style={styles.infoTitle}>Reset Recommendations</Text>
+            <Text style={styles.infoDescription}>
+              Clear everything the For You feed has learned about you. This removes your view
+              history, "not interested" feedback, and learned preferences. The feed will go back
+              to showing non-personalized content until you interact with new posts.
+            </Text>
+          </View>
+          <Pressable
+            style={styles.resetButton}
+            onPress={() => setConfirmVisible(true)}
+            disabled={resetting}
+          >
+            <Ionicons name="refresh-outline" size={18} color="#EF4444" />
+            <Text style={styles.resetButtonText}>Reset Recommendations</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+
+      <Modal
+        visible={confirmVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={() => !resetting && setConfirmVisible(false)}
+      >
+        <Pressable
+          style={styles.modalOverlay}
+          onPress={() => !resetting && setConfirmVisible(false)}
+        >
+          <Pressable style={styles.modalBox} onPress={(e) => e.stopPropagation()}>
+            <View style={styles.modalIconRow}>
+              <Ionicons name="refresh-circle-outline" size={32} color="#EF4444" />
+            </View>
+            <Text style={styles.modalTitle}>Reset recommendations?</Text>
+            <Text style={styles.modalMessage}>This will permanently clear:</Text>
+            <View style={styles.bulletList}>
+              <Text style={styles.bullet}>{"•  Your view history"}</Text>
+              <Text style={styles.bullet}>{"•  ‘Not interested’ feedback"}</Text>
+              <Text style={styles.bullet}>{"•  Learned preferences"}</Text>
+            </View>
+            <Text style={styles.modalFootnote}>
+              Your posts, likes, saves, and follows are not affected.
+            </Text>
+            <Pressable
+              style={[styles.modalConfirmButton, resetting && { opacity: 0.6 }]}
+              onPress={handleConfirmReset}
+              disabled={resetting}
+            >
+              {resetting ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.modalConfirmText}>Yes, Reset</Text>
+              )}
+            </Pressable>
+            <Pressable
+              style={styles.modalCancelButton}
+              onPress={() => setConfirmVisible(false)}
+              disabled={resetting}
+            >
+              <Text style={styles.modalCancelText}>Cancel</Text>
+            </Pressable>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#F8FAFC",
+  },
+  scrollView: {
+    flex: 1,
+  },
+  scrollContent: {
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 40,
+  },
+  sectionHeader: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#94A3B8",
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    marginBottom: 8,
+    marginLeft: 4,
+  },
+  card: {
+    backgroundColor: "#FFFFFF",
+    borderRadius: 18,
+    padding: 16,
+  },
+  infoBlock: {
+    marginBottom: 16,
+  },
+  infoTitle: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#0F172A",
+    marginBottom: 6,
+  },
+  infoDescription: {
+    fontSize: 13,
+    color: "#64748B",
+    lineHeight: 19,
+  },
+  resetButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 8,
+    paddingVertical: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#FECACA",
+    backgroundColor: "#FEF2F2",
+  },
+  resetButtonText: {
+    color: "#EF4444",
+    fontWeight: "600",
+    fontSize: 15,
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+  },
+  modalBox: {
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    padding: 24,
+    width: "100%",
+    maxWidth: 340,
+  },
+  modalIconRow: {
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  modalTitle: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#0F172A",
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  modalMessage: {
+    fontSize: 14,
+    color: "#64748B",
+    textAlign: "center",
+    marginBottom: 10,
+  },
+  bulletList: {
+    alignSelf: "center",
+    marginBottom: 12,
+  },
+  bullet: {
+    fontSize: 14,
+    color: "#0F172A",
+    lineHeight: 22,
+  },
+  modalFootnote: {
+    fontSize: 12,
+    color: "#94A3B8",
+    textAlign: "center",
+    marginBottom: 20,
+  },
+  modalConfirmButton: {
+    backgroundColor: "#EF4444",
+    paddingVertical: 14,
+    borderRadius: 10,
+    alignItems: "center",
+    marginBottom: 10,
+  },
+  modalConfirmText: {
+    color: "#fff",
+    fontWeight: "700",
+    fontSize: 15,
+  },
+  modalCancelButton: {
+    paddingVertical: 12,
+    alignItems: "center",
+  },
+  modalCancelText: {
+    color: "#64748B",
+    fontSize: 15,
+    fontWeight: "500",
+  },
+});

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -131,6 +131,14 @@ export default function Settings() {
           <View style={styles.divider} />
           <Pressable
             style={styles.navRow}
+            onPress={() => router.push("/profile/settings/data-storage" as any)}
+          >
+            <Text style={styles.navLabel}>Data & Storage</Text>
+            <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
+          </Pressable>
+          <View style={styles.divider} />
+          <Pressable
+            style={styles.navRow}
             onPress={() => router.push("/profile/settings/help" as any)}
           >
             <Text style={styles.navLabel}>Help & Support</Text>

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -56,4 +56,5 @@ export { fetchPantryItems, createPantryItem, updatePantryItem, deletePantryItem,
 export type { PantryItem, PantryItemInput, IdentifiedItem, SingleItemResult } from './pantry';
 export { sendChatMessage, fetchChatHistory } from './chat';
 export type { ChatMessage } from './chat';
-export { trackPostView, markPostNotInterested, removeNotInterestedFeedback, getNotInterestedPosts } from './interactions';
+export { trackPostView, markPostNotInterested, removeNotInterestedFeedback, getNotInterestedPosts, resetRecommendations } from './interactions';
+export type { ResetRecommendationsResponse } from './interactions';

--- a/frontend/services/api/interactions.ts
+++ b/frontend/services/api/interactions.ts
@@ -93,3 +93,34 @@ export async function getNotInterestedPosts(): Promise<{ notInterestedPostIds: s
 
   return response.json();
 }
+
+export interface ResetRecommendationsResponse {
+  message: string;
+  deleted: {
+    impressions: number;
+    negativeFeedback: number;
+    preferenceVector: number;
+  };
+}
+
+/**
+ * Clear all recommendation-signal data for the current user:
+ * view history (post_impressions), "not interested" feedback, and the learned preference vector.
+ * After calling this, the For You feed reverts to non-personalized content.
+ */
+export async function resetRecommendations(): Promise<ResetRecommendationsResponse> {
+  const response = await fetch(`${API_BASE_URL}/api/users/me/reset-recommendations`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(await authHeaders()),
+    },
+  });
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.error || 'Failed to reset recommendations');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- Adds `POST /api/users/me/reset-recommendations` which clears the current user's rows in `post_impressions`, `post_negative_feedback`, and `user_preference_vectors`, returning per-table counts.
- Adds a **Data & Storage** settings screen (`/profile/settings/data-storage`) with a confirmation modal that names exactly what will be cleared: view history, "not interested" feedback, learned preferences.
- Links the new screen from the main Settings index (LEGAL card) so it's discoverable next to Privacy.
- Exposes `resetRecommendations()` in `services/api/interactions.ts` (re-exported from `services/api/index.ts`).

## How it works
The engine's cold-start path (`getUserPreferenceVector` in `backend/src/utils/recommendationEngine.js`) already handles missing rows by computing a neutral vector, so deleting the row cleanly falls back to non-personalized content in the For You feed — no algorithm changes needed.

## Test plan
- [ ] Backend starts without errors (`npm run dev` in `backend/`)
- [ ] `POST /api/users/me/reset-recommendations` with a valid Clerk JWT returns `{ message, deleted: { impressions, negativeFeedback, preferenceVector } }`
- [ ] Seed interactions → call endpoint → verify rows for the user are gone in all three tables
- [ ] After reset, next fetch of the For You feed returns results without a personalization bias (neutral cold-start vector rebuilt on demand)
- [ ] Unauthenticated request returns 401
- [ ] Settings → Data & Storage → Reset Recommendations opens the confirmation modal
- [ ] Confirming shows a loading state, then a success alert with the counts
- [ ] Cancel dismisses the modal without a network call

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)