### PR TITLE
feat(settings): granular per-type notification toggles (#114)

### DIFF
--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -10,10 +10,11 @@ const { requireAuth } = require('../middleware/auth');
  */
 router.post('/check-expiring-all', async (req, res) => {
   try {
-    // Get all users who have expiration notifications enabled
+    // Get all users who have expiration notifications enabled AND global
+    // in-app notifications enabled (issue #113).
     const { data: users, error: usersError } = await supabase
       .from('user_preferences')
-      .select('user_id, expiring_items_threshold')
+      .select('user_id, expiring_items_threshold, notifications_enabled')
       .eq('expiration_notifications_enabled', true);
 
     if (usersError) throw usersError;
@@ -22,6 +23,8 @@ router.post('/check-expiring-all', async (req, res) => {
     let totalCreated = 0;
 
     for (const user of users || []) {
+      // Short-circuit when the user has globally disabled notifications.
+      if (user.notifications_enabled === false) continue;
       const { checked, created } = await checkExpiringItemsForUser(
         user.user_id,
         user.expiring_items_threshold || 7
@@ -53,13 +56,18 @@ router.post('/check-expiring', async (req, res) => {
     // Fetch user preferences
     const { data: prefs, error: prefsError } = await supabase
       .from('user_preferences')
-      .select('expiring_items_threshold, expiration_notifications_enabled')
+      .select('expiring_items_threshold, expiration_notifications_enabled, notifications_enabled')
       .eq('user_id', req.userId)
       .single();
 
     if (prefsError && prefsError.code !== 'PGRST116') throw prefsError;
 
     console.log('[EXPIRING-CHECK] userId:', req.userId, 'prefs:', JSON.stringify(prefs));
+
+    // Short-circuit when the user has globally disabled notifications (#113).
+    if (prefs?.notifications_enabled === false) {
+      return res.json({ checked: 0, created: 0, skipped: true });
+    }
 
     const threshold = prefs?.expiring_items_threshold || 7;
     const { checked, created } = await checkExpiringItemsForUser(req.userId, threshold);

--- a/backend/src/routes/notifications.js
+++ b/backend/src/routes/notifications.js
@@ -64,8 +64,12 @@ router.post('/check-expiring', async (req, res) => {
 
     console.log('[EXPIRING-CHECK] userId:', req.userId, 'prefs:', JSON.stringify(prefs));
 
-    // Short-circuit when the user has globally disabled notifications (#113).
+    // Short-circuit when the user has globally disabled notifications (#113)
+    // or disabled the pantry-expiration type specifically (#114).
     if (prefs?.notifications_enabled === false) {
+      return res.json({ checked: 0, created: 0, skipped: true });
+    }
+    if (prefs?.expiration_notifications_enabled === false) {
       return res.json({ checked: 0, created: 0, skipped: true });
     }
 

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -25,7 +25,8 @@ router.get('/', requireAuth, async (req, res) => {
         cookingSkill: 'beginner',
         maxCookTime: null,
         expiringItemsThreshold: 7,
-        expirationNotificationsEnabled: false
+        expirationNotificationsEnabled: false,
+        notificationsEnabled: true
       });
     }
 
@@ -44,7 +45,8 @@ router.get('/', requireAuth, async (req, res) => {
       cookingSkill: data.cooking_skill || 'beginner',
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
-      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false
+      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
+      notificationsEnabled: data.notifications_enabled ?? true
     });
   } catch (error) {
     console.error('Error fetching preferences:', error);
@@ -145,6 +147,14 @@ router.put('/', requireAuth, async (req, res) => {
       updates.expiration_notifications_enabled = expirationNotificationsEnabled;
     }
 
+    const { notificationsEnabled } = req.body;
+    if (notificationsEnabled !== undefined) {
+      if (typeof notificationsEnabled !== 'boolean') {
+        return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+      }
+      updates.notifications_enabled = notificationsEnabled;
+    }
+
     const { data, error } = await supabase
       .from('user_preferences')
       .upsert(updates, { onConflict: 'user_id' })
@@ -169,10 +179,64 @@ router.put('/', requireAuth, async (req, res) => {
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
       expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
+      notificationsEnabled: data.notifications_enabled ?? true,
     });
   } catch (error) {
     console.error('Error updating preferences:', error);
     res.status(500).json({ error: 'Failed to update preferences.' });
+  }
+});
+
+// GET /api/preferences/notifications - Get notification preferences
+router.get('/notifications', requireAuth, async (req, res) => {
+  try {
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .select('notifications_enabled')
+      .eq('user_id', req.userId)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    res.json({
+      notificationsEnabled: data?.notifications_enabled ?? true,
+    });
+  } catch (error) {
+    console.error('Error fetching notification preferences:', error);
+    res.status(500).json({ error: 'Failed to fetch notification preferences.' });
+  }
+});
+
+// PATCH /api/preferences/notifications - Update notification preferences
+router.patch('/notifications', requireAuth, async (req, res) => {
+  try {
+    const { notificationsEnabled } = req.body;
+
+    if (typeof notificationsEnabled !== 'boolean') {
+      return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+    }
+
+    const { data, error } = await supabase
+      .from('user_preferences')
+      .upsert(
+        {
+          user_id: req.userId,
+          notifications_enabled: notificationsEnabled,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id' }
+      )
+      .select('notifications_enabled')
+      .single();
+
+    if (error) throw error;
+
+    res.json({
+      notificationsEnabled: data.notifications_enabled ?? true,
+    });
+  } catch (error) {
+    console.error('Error updating notification preferences:', error);
+    res.status(500).json({ error: 'Failed to update notification preferences.' });
   }
 });
 

--- a/backend/src/routes/preferences.js
+++ b/backend/src/routes/preferences.js
@@ -3,6 +3,28 @@ const router = express.Router();
 const supabase = require('../db/supabase');
 const { requireAuth } = require('../middleware/auth');
 
+// Granular per-type notification preference keys (camelCase <-> snake_case).
+// Source of truth for both GET serialization and PATCH validation. See #114.
+const NOTIFICATION_TYPE_KEYS = [
+  { api: 'notifNewFollower', db: 'notif_new_follower' },
+  { api: 'notifLikes', db: 'notif_likes' },
+  { api: 'notifComments', db: 'notif_comments' },
+  { api: 'notifCommentReplies', db: 'notif_comment_replies' },
+  { api: 'notifAiChat', db: 'notif_ai_chat' },
+  { api: 'notifWeeklyDigest', db: 'notif_weekly_digest' },
+];
+
+function buildNotificationPayload(row) {
+  const payload = {
+    notificationsEnabled: row?.notifications_enabled ?? true,
+    expirationNotificationsEnabled: row?.expiration_notifications_enabled ?? false,
+  };
+  for (const { api, db } of NOTIFICATION_TYPE_KEYS) {
+    payload[api] = row?.[db] ?? true;
+  }
+  return payload;
+}
+
 // GET /api/preferences - Get user preferences (auth required)
 router.get('/', requireAuth, async (req, res) => {
   try {
@@ -26,12 +48,18 @@ router.get('/', requireAuth, async (req, res) => {
         maxCookTime: null,
         expiringItemsThreshold: 7,
         expirationNotificationsEnabled: false,
-        notificationsEnabled: true
+        notificationsEnabled: true,
+        notifNewFollower: true,
+        notifLikes: true,
+        notifComments: true,
+        notifCommentReplies: true,
+        notifAiChat: true,
+        notifWeeklyDigest: true,
       });
     }
 
     // Normalize allergies to string array for frontend compatibility
-    const allergies = Array.isArray(data.allergies) 
+    const allergies = Array.isArray(data.allergies)
       ? data.allergies.map(a => typeof a === 'object' ? a.name : a)
       : [];
 
@@ -45,8 +73,7 @@ router.get('/', requireAuth, async (req, res) => {
       cookingSkill: data.cooking_skill || 'beginner',
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
-      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
-      notificationsEnabled: data.notifications_enabled ?? true
+      ...buildNotificationPayload(data),
     });
   } catch (error) {
     console.error('Error fetching preferences:', error);
@@ -155,6 +182,15 @@ router.put('/', requireAuth, async (req, res) => {
       updates.notifications_enabled = notificationsEnabled;
     }
 
+    for (const { api, db } of NOTIFICATION_TYPE_KEYS) {
+      const value = req.body[api];
+      if (value === undefined) continue;
+      if (typeof value !== 'boolean') {
+        return res.status(400).json({ error: `${api} must be a boolean.` });
+      }
+      updates[db] = value;
+    }
+
     const { data, error } = await supabase
       .from('user_preferences')
       .upsert(updates, { onConflict: 'user_id' })
@@ -178,8 +214,7 @@ router.put('/', requireAuth, async (req, res) => {
       cookingSkill: data.cooking_skill || 'beginner',
       maxCookTime: data.max_cook_time || null,
       expiringItemsThreshold: data.expiring_items_threshold || 7,
-      expirationNotificationsEnabled: data.expiration_notifications_enabled ?? false,
-      notificationsEnabled: data.notifications_enabled ?? true,
+      ...buildNotificationPayload(data),
     });
   } catch (error) {
     console.error('Error updating preferences:', error);
@@ -190,17 +225,21 @@ router.put('/', requireAuth, async (req, res) => {
 // GET /api/preferences/notifications - Get notification preferences
 router.get('/notifications', requireAuth, async (req, res) => {
   try {
+    const selectColumns = [
+      'notifications_enabled',
+      'expiration_notifications_enabled',
+      ...NOTIFICATION_TYPE_KEYS.map(({ db }) => db),
+    ].join(', ');
+
     const { data, error } = await supabase
       .from('user_preferences')
-      .select('notifications_enabled')
+      .select(selectColumns)
       .eq('user_id', req.userId)
       .maybeSingle();
 
     if (error) throw error;
 
-    res.json({
-      notificationsEnabled: data?.notifications_enabled ?? true,
-    });
+    res.json(buildNotificationPayload(data));
   } catch (error) {
     console.error('Error fetching notification preferences:', error);
     res.status(500).json({ error: 'Failed to fetch notification preferences.' });
@@ -210,30 +249,59 @@ router.get('/notifications', requireAuth, async (req, res) => {
 // PATCH /api/preferences/notifications - Update notification preferences
 router.patch('/notifications', requireAuth, async (req, res) => {
   try {
-    const { notificationsEnabled } = req.body;
+    const updates = {
+      user_id: req.userId,
+      updated_at: new Date().toISOString(),
+    };
 
-    if (typeof notificationsEnabled !== 'boolean') {
-      return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+    const { notificationsEnabled, expirationNotificationsEnabled } = req.body;
+
+    if (notificationsEnabled !== undefined) {
+      if (typeof notificationsEnabled !== 'boolean') {
+        return res.status(400).json({ error: 'notificationsEnabled must be a boolean.' });
+      }
+      updates.notifications_enabled = notificationsEnabled;
     }
+
+    if (expirationNotificationsEnabled !== undefined) {
+      if (typeof expirationNotificationsEnabled !== 'boolean') {
+        return res.status(400).json({ error: 'expirationNotificationsEnabled must be a boolean.' });
+      }
+      updates.expiration_notifications_enabled = expirationNotificationsEnabled;
+    }
+
+    for (const { api, db } of NOTIFICATION_TYPE_KEYS) {
+      const value = req.body[api];
+      if (value === undefined) continue;
+      if (typeof value !== 'boolean') {
+        return res.status(400).json({ error: `${api} must be a boolean.` });
+      }
+      updates[db] = value;
+    }
+
+    // Require at least one recognized notification field in the body.
+    const hasAny = Object.keys(updates).some(
+      (key) => key !== 'user_id' && key !== 'updated_at'
+    );
+    if (!hasAny) {
+      return res.status(400).json({ error: 'No notification preference fields provided.' });
+    }
+
+    const selectColumns = [
+      'notifications_enabled',
+      'expiration_notifications_enabled',
+      ...NOTIFICATION_TYPE_KEYS.map(({ db }) => db),
+    ].join(', ');
 
     const { data, error } = await supabase
       .from('user_preferences')
-      .upsert(
-        {
-          user_id: req.userId,
-          notifications_enabled: notificationsEnabled,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'user_id' }
-      )
-      .select('notifications_enabled')
+      .upsert(updates, { onConflict: 'user_id' })
+      .select(selectColumns)
       .single();
 
     if (error) throw error;
 
-    res.json({
-      notificationsEnabled: data.notifications_enabled ?? true,
-    });
+    res.json(buildNotificationPayload(data));
   } catch (error) {
     console.error('Error updating notification preferences:', error);
     res.status(500).json({ error: 'Failed to update notification preferences.' });

--- a/backend/src/services/notifications.js
+++ b/backend/src/services/notifications.js
@@ -1,0 +1,132 @@
+const supabase = require('../db/supabase');
+
+/**
+ * Notification dispatch stubs (issue #114).
+ *
+ * Each function below is a future-proof hook: the preference check is wired up
+ * so that once the originating feature lands (e.g. a new follow, a like,
+ * a reply), the event producer can call `dispatch<Type>Notification(...)` and
+ * users' granular toggles will already be respected.
+ *
+ * No call sites exist yet — the source events have not been implemented. Each
+ * stub returns early after consulting the user's preferences so that the
+ * control surface (backend + frontend) can be shipped independently of the
+ * underlying feature work.
+ */
+
+/**
+ * Load the notification-relevant preference row for a user.
+ * Returns null when the row does not exist — callers should treat that as
+ * "all defaults, enabled".
+ */
+async function getPreferences(userId) {
+  const { data, error } = await supabase
+    .from('user_preferences')
+    .select(
+      'notifications_enabled, expiration_notifications_enabled, notif_new_follower, notif_likes, notif_comments, notif_comment_replies, notif_ai_chat, notif_weekly_digest'
+    )
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('[notifications] Failed to load preferences for user', userId, error);
+    return null;
+  }
+
+  return data;
+}
+
+/**
+ * True when the user should receive notifications of the given per-type flag.
+ * Respects the global toggle — a disabled global short-circuits everything.
+ */
+function shouldDispatch(prefs, typeFlagColumn) {
+  if (!prefs) return true; // No row yet: treat as enabled (defaults are true).
+  if (prefs.notifications_enabled === false) return false;
+  if (prefs[typeFlagColumn] === false) return false;
+  return true;
+}
+
+/**
+ * TODO(#114): Call when a user gains a new follower.
+ * Expected call site: the follow-create handler in backend/src/routes/follows.js
+ * once the "create notification on follow" feature is implemented.
+ */
+async function dispatchNewFollowerNotification(userId, actorId) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_new_follower')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='new_follower' and data={ actorId } once the follow-event
+  // integration lands.
+}
+
+/**
+ * TODO(#114): Call when a user's post or comment is liked.
+ * Expected call site: the like-create handler in backend/src/routes/likes.js
+ * once the "create notification on like" feature is implemented.
+ */
+async function dispatchLikeNotification(userId, actorId, targetType, targetId) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_likes')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='like' and data={ actorId, targetType, targetId }.
+}
+
+/**
+ * TODO(#114): Call when someone comments on the user's post.
+ * Expected call site: the comment-create handler in
+ * backend/src/routes/comments.js once comment notifications are wired up.
+ */
+async function dispatchCommentNotification(userId, actorId, postId, commentId) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_comments')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='comment' and data={ actorId, postId, commentId }.
+}
+
+/**
+ * TODO(#114): Call when someone replies to the user's comment.
+ * Expected call site: the comment-reply handler in
+ * backend/src/routes/comments.js once reply notifications are wired up.
+ */
+async function dispatchCommentReplyNotification(userId, actorId, postId, parentCommentId, replyId) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_comment_replies')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='comment_reply' and data={ actorId, postId, parentCommentId, replyId }.
+}
+
+/**
+ * TODO(#114): Call when the AI chat surfaces a proactive suggestion.
+ * Expected call site: the AI-chat pipeline in backend/src/routes/chat.js once
+ * push-style AI suggestions are implemented.
+ */
+async function dispatchAiChatNotification(userId, suggestionPayload) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_ai_chat')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='ai_chat' and data=suggestionPayload.
+}
+
+/**
+ * TODO(#114): Call when the weekly digest cron fires for a user.
+ * Expected call site: a scheduled job under backend/src/jobs once the weekly
+ * digest feature is built.
+ */
+async function dispatchWeeklyDigestNotification(userId, digestPayload) {
+  const prefs = await getPreferences(userId);
+  if (!shouldDispatch(prefs, 'notif_weekly_digest')) return;
+  // TODO(#114): insert a row into the `notifications` table with
+  // type='weekly_digest' and data=digestPayload.
+}
+
+module.exports = {
+  getPreferences,
+  shouldDispatch,
+  dispatchNewFollowerNotification,
+  dispatchLikeNotification,
+  dispatchCommentNotification,
+  dispatchCommentReplyNotification,
+  dispatchAiChatNotification,
+  dispatchWeeklyDigestNotification,
+};

--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -11,6 +11,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/index" options={{ title: 'Settings' }} />
       <Stack.Screen name="settings/preferences" options={{ title: 'Food Preferences' }} />
       <Stack.Screen name="settings/privacy" options={{ title: 'Privacy' }} />
+      <Stack.Screen name="settings/notifications" options={{ title: 'Notifications' }} />
       <Stack.Screen name="settings/blocked" options={{ title: 'Blocked & Muted' }} />
     </Stack>
   );

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -86,6 +86,18 @@ export default function Settings() {
           </View>
         </View>
 
+        {/* NOTIFICATIONS */}
+        <Text style={styles.sectionHeader}>NOTIFICATIONS</Text>
+        <View style={styles.card}>
+          <Pressable
+            style={styles.navRow}
+            onPress={() => router.push("/profile/settings/notifications" as any)}
+          >
+            <Text style={styles.navLabel}>Push Notifications</Text>
+            <Ionicons name="chevron-forward" size={18} color="#94A3B8" />
+          </Pressable>
+        </View>
+
         {/* LEGAL */}
         <Text style={styles.sectionHeader}>LEGAL</Text>
         <View style={styles.card}>

--- a/frontend/app/(tabs)/profile/settings/notifications.tsx
+++ b/frontend/app/(tabs)/profile/settings/notifications.tsx
@@ -1,0 +1,143 @@
+import {
+  View,
+  Text,
+  StyleSheet,
+  Switch,
+  ActivityIndicator,
+  Alert,
+} from "react-native";
+import { useEffect, useState } from "react";
+import {
+  fetchNotificationPreferences,
+  updateNotificationPreferences,
+} from "../../../../services/api";
+import { usePreferences } from "../../../../context/PreferencesContext";
+
+export default function NotificationSettings() {
+  const { preferences, loading: contextLoading } = usePreferences();
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        const { notificationsEnabled } = await fetchNotificationPreferences();
+        if (active) setEnabled(notificationsEnabled);
+      } catch {
+        // Fall back to context value when the dedicated endpoint fails
+        if (active && preferences) {
+          setEnabled(preferences.notificationsEnabled ?? true);
+        } else if (active) {
+          setEnabled(true);
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+  }, [preferences]);
+
+  const handleToggle = async (value: boolean) => {
+    const previous = enabled;
+    setEnabled(value);
+    setSaving(true);
+    try {
+      const result = await updateNotificationPreferences({
+        notificationsEnabled: value,
+      });
+      setEnabled(result.notificationsEnabled);
+    } catch {
+      setEnabled(previous);
+      Alert.alert("Error", "Failed to update notification settings. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading || contextLoading || enabled === null) {
+    return (
+      <View style={[styles.container, styles.centered]}>
+        <ActivityIndicator size="large" color="#007AFF" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.section}>
+        <View style={styles.row}>
+          <View style={styles.rowInfo}>
+            <Text style={styles.rowTitle}>Push Notifications</Text>
+            <Text style={styles.rowDescription}>
+              {enabled
+                ? "You'll receive in-app notifications about your activity."
+                : "In-app notifications are paused. You won't receive any new alerts."}
+            </Text>
+          </View>
+          <Switch
+            value={enabled}
+            onValueChange={handleToggle}
+            disabled={saving}
+            trackColor={{ false: "#ccc", true: "#007AFF" }}
+            thumbColor="#fff"
+            accessibilityLabel="Toggle global notifications"
+            accessibilityRole="switch"
+          />
+        </View>
+      </View>
+
+      <Text style={styles.footnote}>
+        This is a master switch for all in-app notifications. Individual
+        notification types can be configured separately when those controls are
+        added.
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#fff",
+    padding: 20,
+  },
+  centered: {
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  section: {
+    borderTopWidth: 1,
+    borderTopColor: "#eee",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingVertical: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: "#eee",
+  },
+  rowInfo: {
+    flex: 1,
+    marginRight: 16,
+  },
+  rowTitle: {
+    fontSize: 16,
+    fontWeight: "500",
+  },
+  rowDescription: {
+    fontSize: 13,
+    color: "#888",
+    marginTop: 3,
+  },
+  footnote: {
+    marginTop: 20,
+    fontSize: 12,
+    color: "#888",
+    lineHeight: 18,
+  },
+});

--- a/frontend/app/(tabs)/profile/settings/notifications.tsx
+++ b/frontend/app/(tabs)/profile/settings/notifications.tsx
@@ -5,32 +5,102 @@ import {
   Switch,
   ActivityIndicator,
   Alert,
+  ScrollView,
 } from "react-native";
 import { useEffect, useState } from "react";
 import {
   fetchNotificationPreferences,
   updateNotificationPreferences,
-} from "../../../../services/api";
+  NotificationPreferences,
+} from "../../../../services/api/preferences";
 import { usePreferences } from "../../../../context/PreferencesContext";
+
+type TypeKey =
+  | "expirationNotificationsEnabled"
+  | "notifNewFollower"
+  | "notifLikes"
+  | "notifComments"
+  | "notifCommentReplies"
+  | "notifAiChat"
+  | "notifWeeklyDigest";
+
+const NOTIFICATION_TYPES: { key: TypeKey; title: string; description: string }[] = [
+  {
+    key: "notifNewFollower",
+    title: "New followers",
+    description: "When someone starts following you.",
+  },
+  {
+    key: "notifLikes",
+    title: "Likes",
+    description: "When someone likes your post or comment.",
+  },
+  {
+    key: "notifComments",
+    title: "Comments",
+    description: "When someone comments on your post.",
+  },
+  {
+    key: "notifCommentReplies",
+    title: "Comment replies",
+    description: "When someone replies to your comment.",
+  },
+  {
+    key: "expirationNotificationsEnabled",
+    title: "Pantry expiration",
+    description: "When pantry items are close to their expiration date.",
+  },
+  {
+    key: "notifAiChat",
+    title: "AI chat suggestions",
+    description: "Proactive recipe and cooking tips from the AI assistant.",
+  },
+  {
+    key: "notifWeeklyDigest",
+    title: "Weekly digest",
+    description: "A weekly recap of activity you may have missed.",
+  },
+];
+
+const DEFAULT_PREFS: NotificationPreferences = {
+  notificationsEnabled: true,
+  expirationNotificationsEnabled: true,
+  notifNewFollower: true,
+  notifLikes: true,
+  notifComments: true,
+  notifCommentReplies: true,
+  notifAiChat: true,
+  notifWeeklyDigest: true,
+};
 
 export default function NotificationSettings() {
   const { preferences, loading: contextLoading } = usePreferences();
-  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [prefs, setPrefs] = useState<NotificationPreferences | null>(null);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [savingKey, setSavingKey] = useState<keyof NotificationPreferences | null>(null);
 
   useEffect(() => {
     let active = true;
     (async () => {
       try {
-        const { notificationsEnabled } = await fetchNotificationPreferences();
-        if (active) setEnabled(notificationsEnabled);
+        const fetched = await fetchNotificationPreferences();
+        if (active) setPrefs(fetched);
       } catch {
-        // Fall back to context value when the dedicated endpoint fails
+        // Fall back to context values when the dedicated endpoint fails.
         if (active && preferences) {
-          setEnabled(preferences.notificationsEnabled ?? true);
+          setPrefs({
+            notificationsEnabled: preferences.notificationsEnabled ?? true,
+            expirationNotificationsEnabled:
+              preferences.expirationNotificationsEnabled ?? true,
+            notifNewFollower: preferences.notifNewFollower ?? true,
+            notifLikes: preferences.notifLikes ?? true,
+            notifComments: preferences.notifComments ?? true,
+            notifCommentReplies: preferences.notifCommentReplies ?? true,
+            notifAiChat: preferences.notifAiChat ?? true,
+            notifWeeklyDigest: preferences.notifWeeklyDigest ?? true,
+          });
         } else if (active) {
-          setEnabled(true);
+          setPrefs(DEFAULT_PREFS);
         }
       } finally {
         if (active) setLoading(false);
@@ -41,24 +111,23 @@ export default function NotificationSettings() {
     };
   }, [preferences]);
 
-  const handleToggle = async (value: boolean) => {
-    const previous = enabled;
-    setEnabled(value);
-    setSaving(true);
+  const handleToggle = async (key: keyof NotificationPreferences, value: boolean) => {
+    if (!prefs) return;
+    const previous = prefs;
+    setPrefs({ ...prefs, [key]: value });
+    setSavingKey(key);
     try {
-      const result = await updateNotificationPreferences({
-        notificationsEnabled: value,
-      });
-      setEnabled(result.notificationsEnabled);
+      const result = await updateNotificationPreferences({ [key]: value });
+      setPrefs(result);
     } catch {
-      setEnabled(previous);
+      setPrefs(previous);
       Alert.alert("Error", "Failed to update notification settings. Please try again.");
     } finally {
-      setSaving(false);
+      setSavingKey(null);
     }
   };
 
-  if (loading || contextLoading || enabled === null) {
+  if (loading || contextLoading || !prefs) {
     return (
       <View style={[styles.container, styles.centered]}>
         <ActivityIndicator size="large" color="#007AFF" />
@@ -66,22 +135,24 @@ export default function NotificationSettings() {
     );
   }
 
+  const globalEnabled = prefs.notificationsEnabled;
+
   return (
-    <View style={styles.container}>
+    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <View style={styles.section}>
         <View style={styles.row}>
           <View style={styles.rowInfo}>
             <Text style={styles.rowTitle}>Push Notifications</Text>
             <Text style={styles.rowDescription}>
-              {enabled
+              {globalEnabled
                 ? "You'll receive in-app notifications about your activity."
                 : "In-app notifications are paused. You won't receive any new alerts."}
             </Text>
           </View>
           <Switch
-            value={enabled}
-            onValueChange={handleToggle}
-            disabled={saving}
+            value={globalEnabled}
+            onValueChange={(v) => handleToggle("notificationsEnabled", v)}
+            disabled={savingKey !== null}
             trackColor={{ false: "#ccc", true: "#007AFF" }}
             thumbColor="#fff"
             accessibilityLabel="Toggle global notifications"
@@ -90,12 +161,56 @@ export default function NotificationSettings() {
         </View>
       </View>
 
-      <Text style={styles.footnote}>
-        This is a master switch for all in-app notifications. Individual
-        notification types can be configured separately when those controls are
-        added.
+      <Text style={styles.sectionHeader}>Notification types</Text>
+      <Text style={styles.sectionSubtitle}>
+        Choose which kinds of in-app notifications you want to receive. These
+        are ignored while the master switch above is off.
       </Text>
-    </View>
+
+      <View style={styles.section}>
+        {NOTIFICATION_TYPES.map(({ key, title, description }, idx) => {
+          const value = prefs[key] as boolean;
+          const disabled = !globalEnabled || savingKey !== null;
+          return (
+            <View
+              key={key}
+              style={[
+                styles.row,
+                idx === NOTIFICATION_TYPES.length - 1 && styles.rowLast,
+              ]}
+            >
+              <View style={styles.rowInfo}>
+                <Text
+                  style={[
+                    styles.rowTitle,
+                    !globalEnabled && styles.textDisabled,
+                  ]}
+                >
+                  {title}
+                </Text>
+                <Text
+                  style={[
+                    styles.rowDescription,
+                    !globalEnabled && styles.textDisabled,
+                  ]}
+                >
+                  {description}
+                </Text>
+              </View>
+              <Switch
+                value={value}
+                onValueChange={(v) => handleToggle(key, v)}
+                disabled={disabled}
+                trackColor={{ false: "#ccc", true: "#007AFF" }}
+                thumbColor="#fff"
+                accessibilityLabel={`Toggle ${title} notifications`}
+                accessibilityRole="switch"
+              />
+            </View>
+          );
+        })}
+      </View>
+    </ScrollView>
   );
 }
 
@@ -103,15 +218,34 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: "#fff",
+  },
+  content: {
     padding: 20,
+    paddingBottom: 40,
   },
   centered: {
+    flex: 1,
     justifyContent: "center",
     alignItems: "center",
   },
   section: {
     borderTopWidth: 1,
     borderTopColor: "#eee",
+  },
+  sectionHeader: {
+    marginTop: 28,
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#666",
+    textTransform: "uppercase",
+    letterSpacing: 0.4,
+  },
+  sectionSubtitle: {
+    marginTop: 6,
+    marginBottom: 8,
+    fontSize: 13,
+    color: "#888",
+    lineHeight: 18,
   },
   row: {
     flexDirection: "row",
@@ -120,6 +254,9 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
     borderBottomWidth: 1,
     borderBottomColor: "#eee",
+  },
+  rowLast: {
+    borderBottomWidth: 0,
   },
   rowInfo: {
     flex: 1,
@@ -134,10 +271,7 @@ const styles = StyleSheet.create({
     color: "#888",
     marginTop: 3,
   },
-  footnote: {
-    marginTop: 20,
-    fontSize: 12,
-    color: "#888",
-    lineHeight: 18,
+  textDisabled: {
+    color: "#bbb",
   },
 });

--- a/frontend/context/PreferencesContext.tsx
+++ b/frontend/context/PreferencesContext.tsx
@@ -10,6 +10,12 @@ export interface Preferences {
   expiringItemsThreshold: number;
   expirationNotificationsEnabled: boolean;
   notificationsEnabled: boolean;
+  notifNewFollower: boolean;
+  notifLikes: boolean;
+  notifComments: boolean;
+  notifCommentReplies: boolean;
+  notifAiChat: boolean;
+  notifWeeklyDigest: boolean;
   profileVisibility: "public" | "private";
   dietaryInfoVisible: boolean;
 }
@@ -33,6 +39,12 @@ const DEFAULT_PREFERENCES: Preferences = {
   expiringItemsThreshold: 7,
   expirationNotificationsEnabled: false,
   notificationsEnabled: true,
+  notifNewFollower: true,
+  notifLikes: true,
+  notifComments: true,
+  notifCommentReplies: true,
+  notifAiChat: true,
+  notifWeeklyDigest: true,
   profileVisibility: "public",
   dietaryInfoVisible: true,
 };
@@ -58,6 +70,12 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         expiringItemsThreshold: prefs.expiringItemsThreshold ?? 7,
         expirationNotificationsEnabled: prefs.expirationNotificationsEnabled ?? false,
         notificationsEnabled: prefs.notificationsEnabled ?? true,
+        notifNewFollower: prefs.notifNewFollower ?? true,
+        notifLikes: prefs.notifLikes ?? true,
+        notifComments: prefs.notifComments ?? true,
+        notifCommentReplies: prefs.notifCommentReplies ?? true,
+        notifAiChat: prefs.notifAiChat ?? true,
+        notifWeeklyDigest: prefs.notifWeeklyDigest ?? true,
         profileVisibility: prefs.profileVisibility || "public",
         dietaryInfoVisible: prefs.dietaryInfoVisible ?? true,
       });

--- a/frontend/context/PreferencesContext.tsx
+++ b/frontend/context/PreferencesContext.tsx
@@ -9,6 +9,7 @@ export interface Preferences {
   cuisines: string[];
   expiringItemsThreshold: number;
   expirationNotificationsEnabled: boolean;
+  notificationsEnabled: boolean;
   profileVisibility: "public" | "private";
   dietaryInfoVisible: boolean;
 }
@@ -31,6 +32,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   cuisines: [],
   expiringItemsThreshold: 7,
   expirationNotificationsEnabled: false,
+  notificationsEnabled: true,
   profileVisibility: "public",
   dietaryInfoVisible: true,
 };
@@ -55,6 +57,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         cuisines: prefs.cuisines || [],
         expiringItemsThreshold: prefs.expiringItemsThreshold ?? 7,
         expirationNotificationsEnabled: prefs.expirationNotificationsEnabled ?? false,
+        notificationsEnabled: prefs.notificationsEnabled ?? true,
         profileVisibility: prefs.profileVisibility || "public",
         dietaryInfoVisible: prefs.dietaryInfoVisible ?? true,
       });

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -38,7 +38,7 @@ export type { FollowRequest } from './follows';
 export { savePost, unsavePost, checkSaveStatus, fetchCollections, createCollection, deleteCollection, addPostToCollection, removePostFromCollection, fetchCollectionPosts } from './collections';
 export { reportContent } from './reports';
 export { checkBlockStatus, checkMuteStatus, blockUser, unblockUser, muteUser, unmuteUser, fetchBlockedUsers, fetchMutedUsers } from './blocks';
-export { fetchPreferences, updatePreferences } from './preferences';
+export { fetchPreferences, updatePreferences, fetchNotificationPreferences, updateNotificationPreferences } from './preferences';
 export { fetchNotifications, markNotificationRead, markAllNotificationsRead, clearAllNotifications, fetchUnreadNotificationCount, checkExpiringItems } from './notifications';
 export type { Notification } from './notifications';
 export { fetchAdminUsers, updateUserRole, fetchAdminStats, updateUserVerification } from './admin';

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -39,6 +39,7 @@ export { savePost, unsavePost, checkSaveStatus, fetchCollections, createCollecti
 export { reportContent } from './reports';
 export { checkBlockStatus, checkMuteStatus, blockUser, unblockUser, muteUser, unmuteUser, fetchBlockedUsers, fetchMutedUsers } from './blocks';
 export { fetchPreferences, updatePreferences, fetchNotificationPreferences, updateNotificationPreferences } from './preferences';
+export type { NotificationPreferences } from './preferences';
 export { fetchNotifications, markNotificationRead, markAllNotificationsRead, clearAllNotifications, fetchUnreadNotificationCount, checkExpiringItems } from './notifications';
 export type { Notification } from './notifications';
 export { fetchAdminUsers, updateUserRole, fetchAdminStats, updateUserVerification } from './admin';

--- a/frontend/services/api/preferences.ts
+++ b/frontend/services/api/preferences.ts
@@ -19,6 +19,7 @@ export async function updatePreferences(prefs: {
   dietaryInfoVisible?: boolean;
   expiringItemsThreshold?: number;
   expirationNotificationsEnabled?: boolean;
+  notificationsEnabled?: boolean;
 }) {
   const response = await fetch(`${API_BASE_URL}/api/preferences`, {
     method: 'PUT',
@@ -28,6 +29,32 @@ export async function updatePreferences(prefs: {
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.error || 'Failed to update preferences');
+  }
+  return response.json();
+}
+
+export async function fetchNotificationPreferences(): Promise<{ notificationsEnabled: boolean }> {
+  const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
+    headers: await authHeaders(),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to fetch notification preferences');
+  }
+  return response.json();
+}
+
+export async function updateNotificationPreferences(
+  prefs: { notificationsEnabled: boolean }
+): Promise<{ notificationsEnabled: boolean }> {
+  const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
+    body: JSON.stringify(prefs),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to update notification preferences');
   }
   return response.json();
 }

--- a/frontend/services/api/preferences.ts
+++ b/frontend/services/api/preferences.ts
@@ -1,5 +1,16 @@
 import { API_BASE_URL, authHeaders } from './client';
 
+export interface NotificationPreferences {
+  notificationsEnabled: boolean;
+  expirationNotificationsEnabled: boolean;
+  notifNewFollower: boolean;
+  notifLikes: boolean;
+  notifComments: boolean;
+  notifCommentReplies: boolean;
+  notifAiChat: boolean;
+  notifWeeklyDigest: boolean;
+}
+
 export async function fetchPreferences() {
   const response = await fetch(`${API_BASE_URL}/api/preferences`, {
     headers: await authHeaders(),
@@ -20,6 +31,12 @@ export async function updatePreferences(prefs: {
   expiringItemsThreshold?: number;
   expirationNotificationsEnabled?: boolean;
   notificationsEnabled?: boolean;
+  notifNewFollower?: boolean;
+  notifLikes?: boolean;
+  notifComments?: boolean;
+  notifCommentReplies?: boolean;
+  notifAiChat?: boolean;
+  notifWeeklyDigest?: boolean;
 }) {
   const response = await fetch(`${API_BASE_URL}/api/preferences`, {
     method: 'PUT',
@@ -33,7 +50,7 @@ export async function updatePreferences(prefs: {
   return response.json();
 }
 
-export async function fetchNotificationPreferences(): Promise<{ notificationsEnabled: boolean }> {
+export async function fetchNotificationPreferences(): Promise<NotificationPreferences> {
   const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
     headers: await authHeaders(),
   });
@@ -45,8 +62,8 @@ export async function fetchNotificationPreferences(): Promise<{ notificationsEna
 }
 
 export async function updateNotificationPreferences(
-  prefs: { notificationsEnabled: boolean }
-): Promise<{ notificationsEnabled: boolean }> {
+  prefs: Partial<NotificationPreferences>
+): Promise<NotificationPreferences> {
   const response = await fetch(`${API_BASE_URL}/api/preferences/notifications`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },

--- a/supabase/migrations/20260423000000_add_notifications_enabled.sql
+++ b/supabase/migrations/20260423000000_add_notifications_enabled.sql
@@ -1,0 +1,6 @@
+-- Add notifications_enabled column to user_preferences
+-- Global in-app notification toggle. When false, the notification dispatch
+-- path short-circuits and no new notification records are created for the
+-- user. See GitHub issue #113.
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS notifications_enabled BOOLEAN NOT NULL DEFAULT true;

--- a/supabase/migrations/20260423100000_add_granular_notification_prefs.sql
+++ b/supabase/migrations/20260423100000_add_granular_notification_prefs.sql
@@ -1,0 +1,13 @@
+-- Add granular per-type notification preference columns to user_preferences.
+-- Extends the global notifications_enabled toggle from issue #113 so users can
+-- mute individual notification categories independently. See GitHub issue #114.
+--
+-- Note: pantry-expiration notifications continue to use the existing
+-- expiration_notifications_enabled column and are NOT duplicated here.
+ALTER TABLE user_preferences
+  ADD COLUMN IF NOT EXISTS notif_new_follower BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notif_likes BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notif_comments BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notif_comment_replies BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notif_ai_chat BOOLEAN NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS notif_weekly_digest BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
Closes #114.

## Summary
Adds per-type notification preferences on top of the global toggle from #113. Users can now mute individual categories (new followers, likes, comments, comment replies, pantry expiration, AI chat, weekly digest) without disabling all notifications.

**Builds on #212 (global toggle, #113) — merge that first.** This branch is cut from `feat/settings-global-notif-toggle`. Once #212 lands, please retarget the base if needed.

**Dispatch stubs for follows / likes / comments / replies / AI / digest are in place but unwired** — the originating events (e.g. a new follow creating a notification row) are tracked in separate issues and explicitly out of scope here. The stubs already gate on the new per-type flag and the global toggle so future event producers only need to call `dispatch<Type>Notification(...)`.

## Scope (locked)
In-app only. No Expo / FCM / APNs push infrastructure.

## Changes
- `supabase/migrations/20260423100000_add_granular_notification_prefs.sql` — adds 6 BOOLEAN columns (`notif_new_follower`, `notif_likes`, `notif_comments`, `notif_comment_replies`, `notif_ai_chat`, `notif_weekly_digest`), all `NOT NULL DEFAULT true`. Pantry expiration intentionally reuses the existing `expiration_notifications_enabled` column.
- `backend/src/routes/preferences.js` — `GET` and `PUT /api/preferences` and `GET`/`PATCH /api/preferences/notifications` now read/write the full per-type payload; PATCH accepts any subset.
- `backend/src/services/notifications.js` (new) — `dispatch{NewFollower,Like,Comment,CommentReply,AiChat,WeeklyDigest}Notification` stubs that check the global toggle + per-type flag. Each stub has a TODO pointing at the future call site.
- `backend/src/routes/notifications.js` — `/check-expiring` short-circuit now also respects `expiration_notifications_enabled` (the cron endpoint already filtered by it at the DB query).
- `frontend/services/api/preferences.ts` + `frontend/context/PreferencesContext.tsx` — typed `NotificationPreferences` shape, plumbing for the 6 new fields.
- `frontend/app/(tabs)/profile/settings/notifications.tsx` — keeps the master switch from #113; adds a "Notification types" section with 7 switches that grey out (but preserve persisted values) when the master switch is off. Each toggle PATCHes immediately with optimistic update + rollback on failure.

## Test plan
- [ ] Apply the migration locally and confirm the 6 new columns exist with default `true`.
- [ ] `curl GET /api/preferences/notifications` returns all 8 fields (master + expiration + 6 per-type).
- [ ] `curl PATCH /api/preferences/notifications` with a multi-field body updates only the provided fields.
- [ ] `PATCH` with a non-boolean field returns 400.
- [ ] In the app, toggle the master switch off — per-type rows grey out and become uninteractive but their values persist.
- [ ] Toggle a per-type switch — round-trips to the server and survives reload.
- [ ] `/check-expiring` returns `{ skipped: true }` when `expiration_notifications_enabled` is false.
- [ ] `grep` confirms the dispatch stubs are not called from anywhere outside `services/notifications.js` (intentional — source events not implemented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)