### PR TITLE
fix(db): add missing create migrations for recommendation tables

### DIFF
--- a/supabase/migrations/20260419000000_create_recommendation_engine_tables.sql
+++ b/supabase/migrations/20260419000000_create_recommendation_engine_tables.sql
@@ -1,0 +1,46 @@
+-- Creates the recommendation-engine tables referenced by the existing
+-- 20260420000000_add_cold_start_recommendation_weights.sql migration and by
+-- backend/src/db/schema.sql. These CREATE statements were previously only in
+-- schema.sql but never captured as migrations, causing the migration chain
+-- to fail when applied from scratch.
+
+CREATE TABLE IF NOT EXISTS post_impressions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  view_start_at TIMESTAMPTZ NOT NULL,
+  view_end_at TIMESTAMPTZ,
+  duration_seconds INTEGER,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS idx_post_impressions_post_id ON post_impressions(post_id);
+CREATE INDEX IF NOT EXISTS idx_post_impressions_user_id ON post_impressions(user_id);
+CREATE INDEX IF NOT EXISTS idx_post_impressions_created_at ON post_impressions(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS post_negative_feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  post_id UUID NOT NULL REFERENCES posts(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL,
+  feedback_type TEXT NOT NULL DEFAULT 'not_interested' CHECK (feedback_type IN ('not_interested', 'not_relevant')),
+  created_at TIMESTAMPTZ DEFAULT now(),
+  UNIQUE (post_id, user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_post_negative_feedback_post_id ON post_negative_feedback(post_id);
+CREATE INDEX IF NOT EXISTS idx_post_negative_feedback_user_id ON post_negative_feedback(user_id);
+CREATE INDEX IF NOT EXISTS idx_post_negative_feedback_created_at ON post_negative_feedback(created_at DESC);
+
+CREATE TABLE IF NOT EXISTS user_preference_vectors (
+  user_id TEXT PRIMARY KEY REFERENCES user_profiles(id) ON DELETE CASCADE,
+  cuisine_scores JSONB DEFAULT '{}'::jsonb,
+  meal_type_scores JSONB DEFAULT '{}'::jsonb,
+  dietary_scores JSONB DEFAULT '{}'::jsonb,
+  avg_engagement_score NUMERIC(3,2) DEFAULT 0.5,
+  recent_interaction_count INTEGER DEFAULT 0,
+  total_interaction_count INTEGER DEFAULT 0,
+  preferred_cook_time_range JSONB DEFAULT '{"min": 5, "max": 60}'::jsonb,
+  difficulty_preference TEXT DEFAULT 'beginner' CHECK (difficulty_preference IN ('beginner', 'intermediate', 'advanced')),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  calculated_at TIMESTAMPTZ,
+  vector_version INTEGER DEFAULT 1
+);
+CREATE INDEX IF NOT EXISTS idx_user_preference_vectors_updated ON user_preference_vectors(updated_at DESC);


### PR DESCRIPTION
## Summary

The Validate Migrations CI has been failing on every PR since 2026-04-21 with:

\`\`\`
ERROR: relation "user_preference_vectors" does not exist (SQLSTATE 42P01)
At statement: ALTER TABLE user_preference_vectors ADD COLUMN IF NOT EXISTS cold_start_weight ...
\`\`\`

Root cause: three recommendation-engine tables (\`user_preference_vectors\`, \`post_impressions\`, \`post_negative_feedback\`) exist in \`backend/src/db/schema.sql\` but no migration ever created them. The existing \`20260420000000_add_cold_start_recommendation_weights.sql\` ALTER migration assumes they exist, so fresh migration runs fail.

## Fix

Adds \`20260419000000_create_recommendation_engine_tables.sql\` that creates all three tables with their indexes, matching \`schema.sql\`. The migration is timestamped one day before the cold-start ALTER so it runs first. \`cold_start_weight\` and \`behavioral_weight\` are intentionally omitted here — the existing \`20260420000000\` migration adds them, and the chain now applies cleanly.

## Test plan

- [x] Migration file added with correct timestamp ordering
- [ ] CI \`Validate Migrations (PR)\` passes on this PR
- [ ] Subsequent PRs (#212, #216, #213) no longer fail on the same error

Required before merging the Iteration 5 PRs (#210, #211, #212, #213, #214, #215, #216) — those all piggyback on this fix.