### PR TITLE
feat: show app storage usage breakdown in settings (#132)

### DIFF
--- a/frontend/app/(tabs)/profile/settings/data-storage.tsx
+++ b/frontend/app/(tabs)/profile/settings/data-storage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useState } from "react";
 import {
   View,
   Text,
@@ -8,6 +8,7 @@ import {
   ScrollView,
   Modal,
   ActivityIndicator,
+  RefreshControl,
 } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import { resetRecommendations } from "../../../../services/api";
@@ -16,6 +17,32 @@ import {
   formatCacheSize,
   getMediaCacheSizeBytes,
 } from "../../../../utils/mediaCache";
+import {
+  getStorageBreakdown,
+  StorageBreakdown,
+} from "../../../../utils/storageUsage";
+
+type IoniconName = React.ComponentProps<typeof Ionicons>["name"];
+
+function StorageBreakdownRow({
+  icon,
+  label,
+  bytes,
+}: {
+  icon: IoniconName;
+  label: string;
+  bytes: number;
+}) {
+  return (
+    <View style={styles.storageRow}>
+      <View style={styles.storageIcon}>
+        <Ionicons name={icon} size={18} color="#475569" />
+      </View>
+      <Text style={styles.storageLabel}>{label}</Text>
+      <Text style={styles.storageValue}>{formatCacheSize(bytes)}</Text>
+    </View>
+  );
+}
 
 export default function DataStorageScreen() {
   const [confirmVisible, setConfirmVisible] = useState(false);
@@ -25,6 +52,10 @@ export default function DataStorageScreen() {
   const [calculatingCache, setCalculatingCache] = useState(true);
   const [cacheConfirmVisible, setCacheConfirmVisible] = useState(false);
   const [clearingCache, setClearingCache] = useState(false);
+
+  const [storage, setStorage] = useState<StorageBreakdown | null>(null);
+  const [calculatingStorage, setCalculatingStorage] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
 
   const refreshCacheSize = useCallback(async () => {
     setCalculatingCache(true);
@@ -38,15 +69,38 @@ export default function DataStorageScreen() {
     }
   }, []);
 
+  const refreshStorageBreakdown = useCallback(async () => {
+    setCalculatingStorage(true);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    try {
+      setStorage(getStorageBreakdown());
+    } catch {
+      setStorage({ cacheBytes: 0, downloadsBytes: 0, appDataBytes: 0, totalBytes: 0 });
+    } finally {
+      setCalculatingStorage(false);
+    }
+  }, []);
+
   useEffect(() => {
     refreshCacheSize();
-  }, [refreshCacheSize]);
+    refreshStorageBreakdown();
+  }, [refreshCacheSize, refreshStorageBreakdown]);
+
+  const handlePullToRefresh = useCallback(async () => {
+    setRefreshing(true);
+    try {
+      await Promise.all([refreshCacheSize(), refreshStorageBreakdown()]);
+    } finally {
+      setRefreshing(false);
+    }
+  }, [refreshCacheSize, refreshStorageBreakdown]);
 
   const handleConfirmClearCache = async () => {
     setClearingCache(true);
     try {
       await clearMediaCache();
       setCacheSizeBytes(getMediaCacheSizeBytes());
+      await refreshStorageBreakdown();
       setCacheConfirmVisible(false);
       Alert.alert(
         "Cache cleared",
@@ -92,7 +146,57 @@ export default function DataStorageScreen() {
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handlePullToRefresh}
+            tintColor="#94A3B8"
+          />
+        }
       >
+        <Text style={styles.sectionHeader}>STORAGE USAGE</Text>
+        <View style={styles.card}>
+          <View style={styles.infoBlock}>
+            <Text style={styles.infoTitle}>On this device</Text>
+            <Text style={styles.infoDescription}>
+              How much space BetrFood is using on your phone. Pull down to recalculate.
+            </Text>
+          </View>
+
+          {calculatingStorage && storage === null ? (
+            <View style={styles.storageLoading}>
+              <ActivityIndicator size="small" color="#94A3B8" />
+            </View>
+          ) : (
+            <View style={styles.storageBreakdown}>
+              <StorageBreakdownRow
+                icon="image-outline"
+                label="Cache"
+                bytes={storage?.cacheBytes ?? 0}
+              />
+              <View style={styles.storageDivider} />
+              <StorageBreakdownRow
+                icon="cloud-download-outline"
+                label="Downloads"
+                bytes={storage?.downloadsBytes ?? 0}
+              />
+              <View style={styles.storageDivider} />
+              <StorageBreakdownRow
+                icon="folder-outline"
+                label="App Data"
+                bytes={storage?.appDataBytes ?? 0}
+              />
+              <View style={[styles.storageDivider, styles.storageTotalDivider]} />
+              <View style={styles.storageRow}>
+                <Text style={styles.storageTotalLabel}>Total</Text>
+                <Text style={styles.storageTotalValue}>
+                  {formatCacheSize(storage?.totalBytes ?? 0)}
+                </Text>
+              </View>
+            </View>
+          )}
+        </View>
+
         <Text style={styles.sectionHeader}>CACHE</Text>
         <View style={styles.card}>
           <View style={styles.infoBlock}>
@@ -309,6 +413,56 @@ const styles = StyleSheet.create({
   cacheSizeValue: {
     fontSize: 15,
     fontWeight: "600",
+    color: "#0F172A",
+  },
+  storageLoading: {
+    paddingVertical: 24,
+    alignItems: "center",
+  },
+  storageBreakdown: {
+    backgroundColor: "#F8FAFC",
+    borderRadius: 12,
+    paddingVertical: 4,
+  },
+  storageRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+  },
+  storageIcon: {
+    width: 28,
+    alignItems: "center",
+  },
+  storageLabel: {
+    flex: 1,
+    marginLeft: 8,
+    fontSize: 14,
+    color: "#0F172A",
+  },
+  storageValue: {
+    fontSize: 14,
+    color: "#475569",
+    fontWeight: "500",
+  },
+  storageDivider: {
+    height: 1,
+    backgroundColor: "#E2E8F0",
+    marginHorizontal: 14,
+  },
+  storageTotalDivider: {
+    marginHorizontal: 0,
+    backgroundColor: "#CBD5E1",
+  },
+  storageTotalLabel: {
+    flex: 1,
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#0F172A",
+  },
+  storageTotalValue: {
+    fontSize: 15,
+    fontWeight: "700",
     color: "#0F172A",
   },
   modalOverlay: {

--- a/frontend/utils/storageUsage.ts
+++ b/frontend/utils/storageUsage.ts
@@ -1,0 +1,42 @@
+import { Directory, Paths } from 'expo-file-system';
+import { getMediaCacheSizeBytes } from './mediaCache';
+
+export type StorageBreakdown = {
+  cacheBytes: number;
+  downloadsBytes: number;
+  appDataBytes: number;
+  totalBytes: number;
+};
+
+function safeDirectorySize(dir: Directory): number {
+  try {
+    if (!dir.exists) return 0;
+    return dir.size ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function getStorageBreakdown(): StorageBreakdown {
+  const cacheBytes = getMediaCacheSizeBytes();
+
+  let downloadsBytes = 0;
+  try {
+    const downloads = new Directory(Paths.document, 'downloads');
+    downloadsBytes = safeDirectorySize(downloads);
+  } catch {}
+
+  let documentBytes = 0;
+  try {
+    documentBytes = safeDirectorySize(Paths.document);
+  } catch {}
+
+  const appDataBytes = Math.max(0, documentBytes - downloadsBytes);
+
+  return {
+    cacheBytes,
+    downloadsBytes,
+    appDataBytes,
+    totalBytes: cacheBytes + downloadsBytes + appDataBytes,
+  };
+}


### PR DESCRIPTION
Closes #132.

## Summary
- Adds a new **Storage Usage** section to **Settings → Data & Storage** showing how much space BetrFood is using on the device.
- Breakdown rows: **Cache**, **Downloads**, **App Data**, with a **Total** at the bottom. Sizes formatted in human-readable units (B/KB/MB/GB).
- Pull-to-refresh on the Data & Storage screen recalculates both the storage breakdown and the cache size.
- Clearing the cache now also refreshes the storage breakdown, so the freed space shows up immediately.

## Files
- `frontend/utils/storageUsage.ts` — new `getStorageBreakdown()` returning cache / downloads / app-data / total bytes. Reuses `getMediaCacheSizeBytes` from #131 for the cache figure.
- `frontend/app/(tabs)/profile/settings/data-storage.tsx` — adds the Storage Usage card, a small `StorageBreakdownRow` helper, pull-to-refresh, and styles. Existing Cache and Reset Recommendations sections are unchanged in behavior.

## Test plan
- [ ] Profile → Settings → Data & Storage → Storage Usage card shows Cache / Downloads / App Data with sizes and a Total.
- [ ] Sizes render in human-readable units (e.g. "12.4 MB"), not raw bytes.
- [ ] Pull down on the screen → activity indicator → values recalculate.
- [ ] Tap Clear Cache → cache size drops and Storage Usage breakdown updates without needing a manual refresh.
- [ ] Reset Recommendations still works as before.