### PR TITLE
Serve FAQ content from backend with view tracking

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -24,6 +24,7 @@ const blocksRouter = require("./routes/blocks");
 const notificationsRouter = require("./routes/notifications");
 const chatRouter = require('./routes/chat');
 const interactionsRouter = require('./routes/interactions');
+const faqRouter = require('./routes/faq');
 const { initializeScheduler } = require('./jobs/scheduler');
 
 const app = express();
@@ -92,6 +93,7 @@ app.use("/api/preferences", preferencesRouter);
 app.use("/api/notifications", notificationsRouter);
 app.use('/api/chat', chatRouter);
 app.use('/api/interactions', interactionsRouter);
+app.use('/api/faq', faqRouter);
 
 // Global error handler — catches multer errors and other unhandled middleware errors
 app.use((err, req, res, next) => {

--- a/backend/src/routes/faq.js
+++ b/backend/src/routes/faq.js
@@ -1,0 +1,84 @@
+const express = require('express');
+const supabase = require('../db/supabase');
+
+const router = express.Router();
+
+function buildFaqResponse(categories, items) {
+  const itemsByCategory = new Map();
+  for (const item of items) {
+    if (!itemsByCategory.has(item.category_id)) {
+      itemsByCategory.set(item.category_id, []);
+    }
+    itemsByCategory.get(item.category_id).push({
+      id: item.id,
+      question: item.question,
+      answer: item.answer,
+    });
+  }
+
+  return categories
+    .map((category) => ({
+      id: category.id,
+      title: category.title,
+      icon: category.icon,
+      items: itemsByCategory.get(category.id) || [],
+    }))
+    .filter((category) => category.items.length > 0);
+}
+
+function getFaqHandler(dbClient = supabase) {
+  return async function getFaq(req, res) {
+    try {
+      const { data: categories, error: categoriesError } = await dbClient
+        .from('faq_categories')
+        .select('id, title, icon, sort_order')
+        .eq('is_published', true)
+        .order('sort_order', { ascending: true });
+
+      if (categoriesError) throw categoriesError;
+
+      const { data: items, error: itemsError } = await dbClient
+        .from('faq_items')
+        .select('id, category_id, question, answer, sort_order')
+        .eq('is_published', true)
+        .order('sort_order', { ascending: true });
+
+      if (itemsError) throw itemsError;
+
+      return res.json({ categories: buildFaqResponse(categories || [], items || []) });
+    } catch (error) {
+      console.error('Error fetching FAQ:', error);
+      return res.status(500).json({ error: 'Failed to load FAQ.' });
+    }
+  };
+}
+
+const getFaq = getFaqHandler();
+
+function recordFaqViewHandler(dbClient = supabase) {
+  return async function recordFaqView(req, res) {
+    const itemId = typeof req.params.id === 'string' ? req.params.id.trim() : '';
+    if (!itemId) {
+      return res.status(400).json({ error: 'Missing FAQ item id.' });
+    }
+    try {
+      const { error } = await dbClient.rpc('record_faq_view', { p_item_id: itemId });
+      if (error) throw error;
+      return res.status(204).send();
+    } catch (error) {
+      console.error('Error recording FAQ view:', error);
+      return res.status(500).json({ error: 'Failed to record FAQ view.' });
+    }
+  };
+}
+
+const recordFaqView = recordFaqViewHandler();
+
+router.get('/', getFaq);
+router.post('/items/:id/view', recordFaqView);
+
+module.exports = router;
+module.exports.getFaqHandler = getFaqHandler;
+module.exports.getFaq = getFaq;
+module.exports.recordFaqViewHandler = recordFaqViewHandler;
+module.exports.recordFaqView = recordFaqView;

--- a/frontend/app/(tabs)/profile/settings/help/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/help/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   View,
   Text,
@@ -7,6 +7,7 @@ import {
   ScrollView,
   TextInput,
   Linking,
+  RefreshControl,
 } from "react-native";
 import { useRouter } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
@@ -15,8 +16,8 @@ import {
   FAQ_CATEGORIES,
   FaqCategory,
   FaqItem,
-  getAllFaqItems,
 } from "../../../../../constants/faq";
+import { fetchFaq, recordFaqView } from "../../../../../services/api";
 import { colors } from "../../../../../constants/theme";
 
 const SUPPORT_EMAIL = "support@betrfood.com";
@@ -25,37 +26,80 @@ type FilteredCategory = FaqCategory & {
   matchedItems: FaqItem[];
 };
 
-function filterCategories(query: string): FilteredCategory[] {
+function filterCategories(
+  categories: FaqCategory[],
+  query: string
+): FilteredCategory[] {
   const normalized = query.trim().toLowerCase();
   if (!normalized) {
-    return FAQ_CATEGORIES.map((category) => ({
+    return categories.map((category) => ({
       ...category,
       matchedItems: category.items,
     }));
   }
-  return FAQ_CATEGORIES.map((category) => {
-    const matchedItems = category.items.filter((item) => {
-      const haystack = `${item.question} ${item.answer}`.toLowerCase();
-      return haystack.includes(normalized);
-    });
-    return { ...category, matchedItems };
-  }).filter((category) => category.matchedItems.length > 0);
+  return categories
+    .map((category) => {
+      const matchedItems = category.items.filter((item) => {
+        const haystack = `${item.question} ${item.answer}`.toLowerCase();
+        return haystack.includes(normalized);
+      });
+      return { ...category, matchedItems };
+    })
+    .filter((category) => category.matchedItems.length > 0);
 }
 
 export default function HelpAndFaqScreen() {
   const router = useRouter();
   const [query, setQuery] = useState("");
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [categories, setCategories] = useState<FaqCategory[]>(FAQ_CATEGORIES);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const filtered = useMemo(() => filterCategories(query), [query]);
+  const loadFaq = async () => {
+    try {
+      const remote = await fetchFaq();
+      if (remote.length > 0) {
+        setCategories(remote);
+      }
+    } catch {
+      // Stay on the bundled fallback if the request fails (offline / server down).
+    }
+  };
+
+  useEffect(() => {
+    loadFaq();
+  }, []);
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await loadFaq();
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  const filtered = useMemo(
+    () => filterCategories(categories, query),
+    [categories, query]
+  );
   const totalMatches = useMemo(
     () => filtered.reduce((sum, c) => sum + c.matchedItems.length, 0),
     [filtered]
   );
-  const totalItems = useMemo(() => getAllFaqItems().length, []);
+  const totalItems = useMemo(
+    () => categories.reduce((sum, c) => sum + c.items.length, 0),
+    [categories]
+  );
 
   const toggle = (itemId: string) => {
-    setExpandedId((current) => (current === itemId ? null : itemId));
+    setExpandedId((current) => {
+      const next = current === itemId ? null : itemId;
+      if (next === itemId) {
+        recordFaqView(itemId).catch(() => {});
+      }
+      return next;
+    });
   };
 
   const openSupportEmail = () => {
@@ -71,6 +115,13 @@ export default function HelpAndFaqScreen() {
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            tintColor={colors.textTertiary}
+          />
+        }
       >
         <View style={styles.heroSection}>
           <Text style={styles.heroTitle}>How can we help?</Text>

--- a/frontend/services/api/faq.ts
+++ b/frontend/services/api/faq.ts
@@ -1,0 +1,32 @@
+import { API_BASE_URL } from './client';
+
+export type FaqItem = {
+  id: string;
+  question: string;
+  answer: string;
+};
+
+export type FaqCategory = {
+  id: string;
+  title: string;
+  icon: string;
+  items: FaqItem[];
+};
+
+export async function fetchFaq(): Promise<FaqCategory[]> {
+  const response = await fetch(`${API_BASE_URL}/api/faq`);
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(text || 'Failed to load FAQ');
+  }
+  const data = await response.json();
+  if (!Array.isArray(data?.categories)) return [];
+  return data.categories;
+}
+
+export async function recordFaqView(itemId: string): Promise<void> {
+  if (!itemId) return;
+  await fetch(`${API_BASE_URL}/api/faq/items/${encodeURIComponent(itemId)}/view`, {
+    method: 'POST',
+  });
+}

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -68,3 +68,5 @@ export type { PantryItem, PantryItemInput, IdentifiedItem, SingleItemResult } fr
 export { sendChatMessage, fetchChatHistory } from './chat';
 export type { ChatMessage } from './chat';
 export { trackPostView, markPostNotInterested, removeNotInterestedFeedback, getNotInterestedPosts } from './interactions';
+export { fetchFaq, recordFaqView } from './faq';
+export type { FaqCategory, FaqItem } from './faq';

--- a/supabase/migrations/20260504000000_create_faq_tables.sql
+++ b/supabase/migrations/20260504000000_create_faq_tables.sql
@@ -1,0 +1,116 @@
+-- faq_categories and faq_items: remotely updatable Help & FAQ content
+-- The Help & Support screen reads from these tables so support staff can
+-- edit answers without shipping a new app build. Rows are public reads;
+-- only service role / admin should be able to insert or update.
+
+CREATE TABLE IF NOT EXISTS faq_categories (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  icon TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_published BOOLEAN NOT NULL DEFAULT TRUE,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_faq_categories_sort_order
+  ON faq_categories(sort_order);
+
+CREATE TABLE IF NOT EXISTS faq_items (
+  id TEXT PRIMARY KEY,
+  category_id TEXT NOT NULL REFERENCES faq_categories(id) ON DELETE CASCADE,
+  question TEXT NOT NULL,
+  answer TEXT NOT NULL,
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  is_published BOOLEAN NOT NULL DEFAULT TRUE,
+  view_count INTEGER NOT NULL DEFAULT 0,
+  last_viewed_at TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_faq_items_category_id
+  ON faq_items(category_id);
+
+CREATE INDEX IF NOT EXISTS idx_faq_items_sort_order
+  ON faq_items(sort_order);
+
+CREATE INDEX IF NOT EXISTS idx_faq_items_view_count
+  ON faq_items(view_count DESC);
+
+-- record_faq_view: increments the view counter and updates last_viewed_at
+-- for an FAQ item. Used by POST /api/faq/items/:id/view from the help screen
+-- whenever a user expands a question. No-op if the id does not exist.
+CREATE OR REPLACE FUNCTION record_faq_view(p_item_id TEXT)
+RETURNS void LANGUAGE plpgsql AS $$
+BEGIN
+  UPDATE faq_items
+  SET
+    view_count = view_count + 1,
+    last_viewed_at = now()
+  WHERE id = p_item_id;
+END;
+$$;
+
+INSERT INTO faq_categories (id, title, icon, sort_order) VALUES
+  ('account', 'Account', 'person-circle-outline', 10),
+  ('pantry', 'Pantry', 'basket-outline', 20),
+  ('posting', 'Posting', 'create-outline', 30),
+  ('notifications', 'Notifications', 'notifications-outline', 40),
+  ('privacy', 'Privacy', 'lock-closed-outline', 50),
+  ('recipes', 'Recipes', 'restaurant-outline', 60),
+  ('troubleshooting', 'Troubleshooting', 'construct-outline', 70)
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO faq_items (id, category_id, question, answer, sort_order) VALUES
+  ('account-create', 'account', 'How do I create a BetrFood account?',
+    'Tap "Sign Up" on the welcome screen and register with your email, Apple, or Google account. You can edit your display name and profile photo any time from the Profile tab.', 10),
+  ('account-reset-password', 'account', 'How do I reset my password?',
+    'From the login screen, tap "Forgot password?" and enter the email linked to your account. We will send a password reset link within a few minutes — check your spam folder if you do not see it.', 20),
+  ('account-change-email', 'account', 'Can I change the email address on my account?',
+    'Yes. Go to Profile > Settings > Account and tap your email address to update it. You will need to verify the new email before the change takes effect.', 30),
+  ('account-delete', 'account', 'How do I delete my account?',
+    'Open Profile > Settings and scroll to the Account section, then tap "Delete Account" and confirm. Deletion is permanent and removes your posts, comments, follows, and saved data.', 40),
+
+  ('pantry-add', 'pantry', 'How do I add an item to my pantry?',
+    'Open the Pantry tab and tap the plus button. You can scan a barcode, search the food database, or add a custom item with your own name and quantity.', 10),
+  ('pantry-expiry', 'pantry', 'Why is an item showing as expired?',
+    'BetrFood tracks expiry dates you enter manually or from barcode scans. If the date looks wrong, tap the item and edit the "Expires on" field to correct it.', 20),
+  ('pantry-recipes', 'pantry', 'How does "Cook with what I have" work?',
+    'We match recipes against the ingredients currently in your pantry, prioritising items nearing expiry. Recipes that require only a couple of extra ingredients are also suggested and labelled accordingly.', 30),
+
+  ('posting-create', 'posting', 'How do I share a recipe or food photo?',
+    'Tap the plus button in the bottom tab bar, choose a photo or video, then add a caption, tags, and optional recipe steps. Posts are visible to your followers immediately after publishing.', 10),
+  ('posting-edit', 'posting', 'Can I edit a post after publishing?',
+    'You can edit the caption, tags, and recipe details of any post you own. Open the post, tap the menu icon in the top right, and choose "Edit". The media itself cannot be changed after publishing.', 20),
+  ('posting-delete', 'posting', 'How do I delete one of my posts?',
+    'Open the post, tap the menu icon, and choose "Delete". Deletion is permanent and will also remove the post''s likes and comments.', 30),
+  ('posting-hashtags', 'posting', 'How do hashtags work?',
+    'Hashtags help others discover your post. Type # followed by a keyword in your caption (for example, #mealprep). Tap any hashtag to see trending posts using the same tag.', 40),
+
+  ('notifications-disable-all', 'notifications', 'How do I turn off all push notifications?',
+    'Go to Profile > Settings > Notifications and toggle "Push notifications" off. This pauses all notification types from BetrFood without affecting your account.', 10),
+  ('notifications-types', 'notifications', 'Can I choose which notifications I get?',
+    'Yes — under Profile > Settings > Notifications you can individually enable or disable likes, comments, follows, mentions, and recipe reminders.', 20),
+  ('notifications-not-arriving', 'notifications', 'Why am I not receiving notifications?',
+    'Check that notifications are enabled both in BetrFood (Settings > Notifications) and in your device''s system settings for BetrFood. Do Not Disturb and focus modes can also silence them.', 30),
+
+  ('privacy-profile', 'privacy', 'How do I make my profile private?',
+    'Go to Profile > Settings > Privacy and turn off "Public Profile". Only accounts you approve as followers will be able to see your posts and activity.', 10),
+  ('privacy-block', 'privacy', 'What happens when I block someone?',
+    'Blocked users cannot see your profile, posts, or comments, and cannot follow or message you. They are not notified that you blocked them.', 20),
+  ('privacy-data', 'privacy', 'What data does BetrFood collect about me?',
+    'We collect the content you create, your pantry and recipe activity, and basic device diagnostics. Full details are in our Privacy Policy, linked from Settings > Legal.', 30),
+
+  ('recipes-save', 'recipes', 'How do I save a recipe for later?',
+    'Tap the bookmark icon on any recipe to save it. Saved recipes appear in Profile > Collections, where you can organise them into folders such as "Weeknight" or "Desserts".', 10),
+  ('recipes-scale', 'recipes', 'Can I scale a recipe up or down?',
+    'Open the recipe and tap the serving count near the top. Adjust it to the number of servings you need — ingredient quantities update automatically.', 20),
+  ('recipes-missing-steps', 'recipes', 'A recipe I posted is missing steps after editing — what happened?',
+    'Recipe steps are saved separately from the caption. If steps appear blank after an edit, reopen the editor, re-add the steps, and save again. If the problem persists, contact support.', 30),
+
+  ('trouble-crash', 'troubleshooting', 'The app keeps crashing — what should I try first?',
+    'Force-quit BetrFood and reopen it, then make sure you are on the latest version from the App Store or Play Store. If it still crashes, restart your device and try again.', 10),
+  ('trouble-upload', 'troubleshooting', 'My photo or video upload keeps failing.',
+    'Uploads need a stable connection. Switch between Wi-Fi and cellular, make sure the file is under 100MB, and retry. If the issue continues, try uploading a smaller version of the media.', 20),
+  ('trouble-contact', 'troubleshooting', 'Something else is wrong — how do I contact support?',
+    'Email support@betrfood.com with a short description of the issue and, if possible, a screenshot. Please include your app version (shown in Settings > App Information) so we can help faster.', 30)
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Closes #133.

## Summary
- The Help & FAQ screen now reads its content from the backend, so support staff can update questions and answers without shipping a new app build.
- Bundled FAQ content stays in `frontend/constants/faq.ts` as a fallback, so the screen still works offline or if the backend is unreachable.
- Added analytics tracking: each FAQ expand fires a fire-and-forget POST that increments `view_count` and updates `last_viewed_at` on the item.
- Added pull-to-refresh on the Help screen.

## Files
- `supabase/migrations/20260504000000_create_faq_tables.sql` — `faq_categories`, `faq_items` (with `view_count`, `last_viewed_at`), seed data matching the current bundled content, plus a `record_faq_view(p_item_id)` RPC.
- `backend/src/routes/faq.js` — `GET /api/faq` (returns published categories with their published items, ordered) and `POST /api/faq/items/:id/view` (calls the RPC).
- `backend/src/index.js` — mounts `/api/faq`.
- `frontend/services/api/faq.ts` — `fetchFaq()` and `recordFaqView(id)`.
- `frontend/services/api/index.ts` — re-exports.
- `frontend/app/(tabs)/profile/settings/help/index.tsx` — fetches on mount, swaps in remote content if the request succeeds, falls back to bundled content otherwise. Records a view every time a user expands a question.

## Test plan
- [ ] Settings → Help & Support → screen loads the same FAQs you see today.
- [ ] Apply the migration, edit a row in `faq_items`, reopen the screen → updated copy appears (no app rebuild).
- [ ] Set `is_published = false` on a row → it disappears from the list.
- [ ] Expand a question → row in `faq_items` for that id has `view_count` incremented and `last_viewed_at` set.
- [ ] Turn off the backend → screen still renders bundled FAQs and search/expand still work.
- [ ] Pull down on the screen → re-fetches from backend.