### PR TITLE
Re-export real fetchTrendingHashtags from api barrel

### DIFF
--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -35,13 +35,13 @@ export { fetchRecipe, createRecipe, updateRecipe, deleteRecipe } from './recipes
 export type { Recipe, RecipeInput, RecipeIngredient, RecipeStep } from './recipes';
 export {
   fetchTags,
-  fetchTags as fetchTrendingHashtags,
+  fetchTrendingHashtags,
   addTagsToPost,
   removeTagFromPost,
   fetchPostTags,
   fetchPostsByTags,
 } from './tags';
-export type { Tag } from './tags';
+export type { Tag, TrendingTag } from './tags';
 export {
   fetchMyProfile,
   updateMyProfile,


### PR DESCRIPTION
## What
Two-line fix to \`frontend/services/api/index.ts\`:
- Replace the broken alias \`fetchTags as fetchTrendingHashtags\` with the real \`fetchTrendingHashtags\` export.
- Add the \`TrendingTag\` type to the re-exports.

## Why
The barrel was aliasing \`fetchTags\` (signature \`(type?: string)\`, hits \`/api/tags\`) under the name \`fetchTrendingHashtags\`. The real \`fetchTrendingHashtags\` (signature \`(limit?: number)\`, hits \`/api/tags/trending\`) was never reachable through the barrel.

This caused two compile errors in \`search.tsx\` and a silent runtime bug — the trending-hashtags section on the search page has been calling the wrong endpoint with a numeric \`type\` parameter, returning unintended data.

## Blast radius
Only \`search.tsx\` imports these symbols from the barrel (verified via grep). No other consumers change behaviour.

## Test plan
- [ ] \`tsc --noEmit\` no longer reports the two errors at \`feeds/search.tsx:35\` and \`feeds/search.tsx:214\`.
- [ ] Open the search page → the trending hashtags section now populates correctly from \`/api/tags/trending\`.