### PR TITLE
fix: hardcode white in ExpiringSoonSection stylesheet

### DIFF
--- a/frontend/components/ExpiringSoonSection.tsx
+++ b/frontend/components/ExpiringSoonSection.tsx
@@ -136,7 +136,7 @@ const styles = StyleSheet.create({
   expiredBadgeText: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.white,
+    color: '#FFFFFF',
   },
   list: {
     paddingHorizontal: 0,
@@ -183,6 +183,6 @@ const styles = StyleSheet.create({
   statusText: {
     fontSize: 11,
     fontWeight: '600',
-    color: colors.white,
+    color: '#FFFFFF',
   },
 });


### PR DESCRIPTION
## What
Replace \`colors.white\` with the literal \`'#FFFFFF'\` on two lines inside \`StyleSheet.create({...})\` in \`frontend/components/ExpiringSoonSection.tsx\`.

## Why
The recent theme refactor (\`8acc0a5\`) moved \`colors\` from a module-level import to a hook (\`const { colors } = useAppTheme()\`) inside the component, but missed these two stylesheet lines. \`StyleSheet.create\` runs at module load — \`colors\` isn't in scope there — so the file throws \`Property 'colors' doesn't exist\` the moment it's imported.

This crashes the entire pantry tab on launch (\`ExpiringSoonSection\` is rendered by the pantry index screen).

## Test plan
- [ ] Pull main, open the app on a fresh build → pantry tab no longer crashes.
- [ ] Items in the Expiring Soon section still render correctly with white text on the red expired badge and on colored status badges.