### PR TITLE
feat: add Change Password in Settings > Account

### DIFF
--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -475,6 +475,75 @@ router.post('/me/email/confirm', requireAuth, async (req, res) => {
   res.json({ message: 'Email address updated successfully.' });
 });
 
+// ── Password Change ────────────────────────────────────────────────────────────
+
+// POST /api/profiles/me/password
+// Verifies current password, updates to new password in Clerk, sends confirmation email.
+router.post('/me/password', requireAuth, async (req, res) => {
+  const userId = req.userId;
+  const { currentPassword, newPassword } = req.body;
+
+  if (!currentPassword || typeof currentPassword !== 'string') {
+    return res.status(400).json({ error: 'Current password is required.' });
+  }
+  if (!newPassword || typeof newPassword !== 'string' || newPassword.length < 8) {
+    return res.status(400).json({ error: 'New password must be at least 8 characters.' });
+  }
+  if (currentPassword === newPassword) {
+    return res.status(400).json({ error: 'New password must be different from your current password.' });
+  }
+
+  // 1. Verify current password
+  let verifyResult;
+  try {
+    verifyResult = await clerkRequest('POST', `/v1/users/${userId}/verify_password`, { password: currentPassword });
+  } catch (err) {
+    console.error('[PASSWORD CHANGE] verify_password error:', err.message);
+    return res.status(500).json({ error: 'Unable to verify password. Please try again.' });
+  }
+
+  if (verifyResult.status !== 200 || !verifyResult.data?.verified) {
+    const clerkCode = verifyResult.data?.errors?.[0]?.code || '';
+    if (clerkCode === 'form_password_not_enabled') {
+      return res.status(400).json({ error: 'Password sign-in is not enabled on this account. Manage your password through your OAuth provider.' });
+    }
+    return res.status(401).json({ error: 'Incorrect current password.' });
+  }
+
+  // 2. Update password in Clerk
+  let updateResult;
+  try {
+    updateResult = await clerkRequest('PATCH', `/v1/users/${userId}`, {
+      password: newPassword,
+      skip_password_checks: false,
+    });
+  } catch (err) {
+    console.error('[PASSWORD CHANGE] update password error:', err.message);
+    return res.status(500).json({ error: 'Failed to update password. Please try again.' });
+  }
+
+  if (updateResult.status !== 200) {
+    const errMsg = updateResult.data?.errors?.[0]?.long_message
+      || updateResult.data?.errors?.[0]?.message
+      || 'Failed to update password.';
+    return res.status(400).json({ error: errMsg });
+  }
+
+  // 3. Send confirmation email (fire-and-forget)
+  getClerkUserEmail(userId).then((userEmail) => {
+    if (!userEmail) return;
+    sendEmail({
+      to: userEmail,
+      subject: 'Your BetrFood password has been changed',
+      text: `Hello,\n\nYour BetrFood account password was successfully changed.\n\nIf you did not make this change, please contact support immediately and reset your password.\n\nThe BetrFood Team`,
+      html: `<p>Hello,</p><p>Your BetrFood account password was successfully changed.</p><p>If you did not make this change, please contact support immediately and reset your password.</p><p>The BetrFood Team</p>`,
+    }).catch((err) => console.error('[PASSWORD CHANGE] Confirmation email failed:', err.message));
+  }).catch(() => {});
+
+  console.log(`[PASSWORD CHANGE] Password updated for user ${userId}`);
+  res.json({ message: 'Password updated successfully.' });
+});
+
 // ── Data Export ────────────────────────────────────────────────────────────────
 
 /**

--- a/frontend/app/(tabs)/profile/_layout.tsx
+++ b/frontend/app/(tabs)/profile/_layout.tsx
@@ -36,6 +36,7 @@ export default function ProfileStack() {
       <Stack.Screen name="settings/export-data" options={{ title: 'Export Data' }} />
       <Stack.Screen name="settings/bug-report" options={{ title: 'Report a Bug' }} />
       <Stack.Screen name="settings/change-email" options={{ title: 'Change Email' }} />
+      <Stack.Screen name="settings/change-password" options={{ title: 'Change Password' }} />
     </Stack>
   );
 }

--- a/frontend/app/(tabs)/profile/settings/change-password.tsx
+++ b/frontend/app/(tabs)/profile/settings/change-password.tsx
@@ -1,0 +1,398 @@
+import React, { useCallback, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+import { router } from "expo-router";
+import { ThemeColors } from "../../../../constants/theme";
+import { useAppTheme } from "../../../../context/ThemeContext";
+import { useScaledTypography } from "../../../../hooks/useScaledTypography";
+import { changePassword } from "../../../../services/api";
+
+// ── Password strength ─────────────────────────────────────────────────────────
+
+interface PasswordCriteria {
+  hasLength: boolean;
+  hasUpper: boolean;
+  hasLower: boolean;
+  hasNumber: boolean;
+  hasSpecial: boolean;
+}
+
+type StrengthLevel = 0 | 1 | 2 | 3 | 4;
+
+function evaluatePassword(password: string): { strength: StrengthLevel; criteria: PasswordCriteria } {
+  const criteria: PasswordCriteria = {
+    hasLength: password.length >= 8,
+    hasLower: /[a-z]/.test(password),
+    hasUpper: /[A-Z]/.test(password),
+    hasNumber: /\d/.test(password),
+    hasSpecial: /[^a-zA-Z0-9]/.test(password),
+  };
+  const met = Object.values(criteria).filter(Boolean).length;
+  const strength: StrengthLevel = met === 0 ? 0 : met <= 2 ? 1 : met === 3 ? 2 : met === 4 ? 3 : 4;
+  return { strength, criteria };
+}
+
+const STRENGTH_LABEL: Record<StrengthLevel, string> = { 0: '', 1: 'Weak', 2: 'Fair', 3: 'Good', 4: 'Strong' };
+const STRENGTH_COLOR: Record<StrengthLevel, string> = {
+  0: 'transparent',
+  1: '#EF4444',
+  2: '#F97316',
+  3: '#22C55E',
+  4: '#16A34A',
+};
+
+const CRITERIA_ITEMS: { key: keyof PasswordCriteria; label: string }[] = [
+  { key: 'hasLength', label: 'At least 8 characters' },
+  { key: 'hasUpper',  label: 'Uppercase letter (A–Z)' },
+  { key: 'hasNumber', label: 'Number (0–9)' },
+  { key: 'hasSpecial', label: 'Special character (!@#…)' },
+];
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function ChangePasswordScreen() {
+  const { colors } = useAppTheme();
+  const scaledTypography = useScaledTypography();
+  const styles = useMemo(() => makeStyles(colors), [colors]);
+
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+
+  const [showCurrent, setShowCurrent] = useState(false);
+  const [showNext, setShowNext] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState("");
+
+  const { strength, criteria } = useMemo(() => evaluatePassword(next), [next]);
+  const strengthColor = STRENGTH_COLOR[strength];
+  const strengthLabel = STRENGTH_LABEL[strength];
+
+  const passwordsMatch = confirm.length > 0 && next === confirm;
+  const passwordsMismatch = confirm.length > 0 && next !== confirm;
+
+  const canSubmit =
+    !submitting &&
+    current.length > 0 &&
+    criteria.hasLength &&
+    passwordsMatch;
+
+  const handleSubmit = useCallback(async () => {
+    setError("");
+
+    if (!current) { setError("Please enter your current password."); return; }
+    if (!criteria.hasLength) { setError("New password must be at least 8 characters."); return; }
+    if (!passwordsMatch) { setError("Passwords do not match."); return; }
+
+    setSubmitting(true);
+    try {
+      await changePassword(current, next);
+      Alert.alert(
+        "Password changed",
+        "Your password has been updated. A confirmation has been sent to your email.",
+        [{ text: "OK", onPress: () => router.back() }]
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Something went wrong.");
+    } finally {
+      setSubmitting(false);
+    }
+  }, [current, next, criteria.hasLength, passwordsMatch]);
+
+  return (
+    <View style={styles.container}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.scrollContent}
+          keyboardShouldPersistTaps="handled"
+          showsVerticalScrollIndicator={false}
+        >
+          {/* ── Current password ── */}
+          <Text style={[scaledTypography.caption, styles.sectionHeader, { color: colors.textTertiary }]}>
+            CURRENT PASSWORD
+          </Text>
+          <View style={[styles.card, { backgroundColor: colors.backgroundElevated }]}>
+            <View style={styles.passwordRow}>
+              <TextInput
+                style={[styles.input, styles.passwordInput, scaledTypography.body, { color: colors.textPrimary, borderColor: colors.border, backgroundColor: colors.backgroundSecondary }]}
+                value={current}
+                onChangeText={(t) => { setCurrent(t); setError(""); }}
+                placeholder="Enter current password"
+                placeholderTextColor={colors.placeholder}
+                secureTextEntry={!showCurrent}
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoComplete="current-password"
+                returnKeyType="next"
+              />
+              <Pressable style={styles.eyeButton} onPress={() => setShowCurrent((v) => !v)} hitSlop={8}>
+                <Ionicons name={showCurrent ? "eye-off-outline" : "eye-outline"} size={20} color={colors.textTertiary} />
+              </Pressable>
+            </View>
+          </View>
+
+          {/* ── New password ── */}
+          <Text style={[scaledTypography.caption, styles.sectionHeader, { color: colors.textTertiary }]}>
+            NEW PASSWORD
+          </Text>
+          <View style={[styles.card, { backgroundColor: colors.backgroundElevated }]}>
+            <View style={styles.passwordRow}>
+              <TextInput
+                style={[styles.input, styles.passwordInput, scaledTypography.body, { color: colors.textPrimary, borderColor: colors.border, backgroundColor: colors.backgroundSecondary }]}
+                value={next}
+                onChangeText={(t) => { setNext(t); setError(""); }}
+                placeholder="Enter new password"
+                placeholderTextColor={colors.placeholder}
+                secureTextEntry={!showNext}
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoComplete="new-password"
+                returnKeyType="next"
+              />
+              <Pressable style={styles.eyeButton} onPress={() => setShowNext((v) => !v)} hitSlop={8}>
+                <Ionicons name={showNext ? "eye-off-outline" : "eye-outline"} size={20} color={colors.textTertiary} />
+              </Pressable>
+            </View>
+
+            {/* Strength bar */}
+            {next.length > 0 && (
+              <View style={styles.strengthContainer}>
+                <View style={styles.strengthBars}>
+                  {([1, 2, 3, 4] as StrengthLevel[]).map((level) => (
+                    <View
+                      key={level}
+                      style={[styles.strengthBar, { backgroundColor: level <= strength ? strengthColor : colors.border }]}
+                    />
+                  ))}
+                </View>
+                <Text style={[scaledTypography.small, { color: strengthColor, minWidth: 42, textAlign: "right" }]}>
+                  {strengthLabel}
+                </Text>
+              </View>
+            )}
+
+            {/* Criteria checklist */}
+            {next.length > 0 && (
+              <View style={styles.criteriaList}>
+                {CRITERIA_ITEMS.map(({ key, label }) => (
+                  <View key={key} style={styles.criteriaRow}>
+                    <Ionicons
+                      name={criteria[key] ? "checkmark-circle" : "ellipse-outline"}
+                      size={15}
+                      color={criteria[key] ? colors.primaryDark : colors.textTertiary}
+                    />
+                    <Text style={[scaledTypography.small, { color: criteria[key] ? colors.primaryDark : colors.textTertiary }]}>
+                      {label}
+                    </Text>
+                  </View>
+                ))}
+              </View>
+            )}
+          </View>
+
+          {/* ── Confirm password ── */}
+          <Text style={[scaledTypography.caption, styles.sectionHeader, { color: colors.textTertiary }]}>
+            CONFIRM NEW PASSWORD
+          </Text>
+          <View style={[styles.card, { backgroundColor: colors.backgroundElevated }]}>
+            <View style={styles.passwordRow}>
+              <TextInput
+                style={[
+                  styles.input,
+                  styles.passwordInput,
+                  scaledTypography.body,
+                  {
+                    color: colors.textPrimary,
+                    backgroundColor: colors.backgroundSecondary,
+                    borderColor: passwordsMismatch ? colors.error : passwordsMatch ? colors.primaryDark : colors.border,
+                  },
+                ]}
+                value={confirm}
+                onChangeText={(t) => { setConfirm(t); setError(""); }}
+                placeholder="Re-enter new password"
+                placeholderTextColor={colors.placeholder}
+                secureTextEntry={!showConfirm}
+                autoCapitalize="none"
+                autoCorrect={false}
+                autoComplete="new-password"
+                returnKeyType="done"
+                onSubmitEditing={handleSubmit}
+              />
+              <Pressable style={styles.eyeButton} onPress={() => setShowConfirm((v) => !v)} hitSlop={8}>
+                <Ionicons name={showConfirm ? "eye-off-outline" : "eye-outline"} size={20} color={colors.textTertiary} />
+              </Pressable>
+            </View>
+
+            {/* Match status */}
+            {confirm.length > 0 && (
+              <View style={styles.matchRow}>
+                <Ionicons
+                  name={passwordsMatch ? "checkmark-circle" : "close-circle"}
+                  size={15}
+                  color={passwordsMatch ? colors.primaryDark : colors.error}
+                />
+                <Text style={[scaledTypography.small, { color: passwordsMatch ? colors.primaryDark : colors.error }]}>
+                  {passwordsMatch ? "Passwords match" : "Passwords do not match"}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          {/* ── Error ── */}
+          {error ? (
+            <View style={[styles.errorCard, { backgroundColor: colors.backgroundElevated, borderColor: colors.error }]}>
+              <Ionicons name="alert-circle-outline" size={16} color={colors.error} />
+              <Text style={[scaledTypography.small, styles.errorText, { color: colors.error }]}>{error}</Text>
+            </View>
+          ) : null}
+
+          {/* ── Submit ── */}
+          <Pressable
+            style={[styles.primaryButton, { backgroundColor: colors.primaryDark }, !canSubmit && styles.buttonDisabled]}
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+          >
+            {submitting ? (
+              <ActivityIndicator color={colors.white} />
+            ) : (
+              <Text style={[scaledTypography.body, styles.primaryButtonText, { color: colors.white }]}>
+                Update Password
+              </Text>
+            )}
+          </Pressable>
+
+          <Text style={[scaledTypography.small, styles.hint, { color: colors.textTertiary }]}>
+            A confirmation email will be sent to your account address after the change.
+          </Text>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </View>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+function makeStyles(colors: ThemeColors) {
+  return StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.backgroundSecondary,
+    },
+    flex: { flex: 1 },
+    scrollContent: {
+      paddingHorizontal: 20,
+      paddingTop: 16,
+      paddingBottom: 48,
+    },
+    sectionHeader: {
+      letterSpacing: 0.5,
+      textTransform: "uppercase",
+      marginTop: 24,
+      marginBottom: 8,
+      marginLeft: 4,
+    },
+    card: {
+      borderRadius: 18,
+      padding: 16,
+    },
+    passwordRow: {
+      position: "relative",
+    },
+    input: {
+      borderWidth: 1,
+      borderRadius: 10,
+      paddingHorizontal: 14,
+      paddingVertical: 12,
+    },
+    passwordInput: {
+      paddingRight: 46,
+    },
+    eyeButton: {
+      position: "absolute",
+      right: 12,
+      top: 0,
+      bottom: 0,
+      justifyContent: "center",
+    },
+    strengthContainer: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 10,
+      marginTop: 12,
+    },
+    strengthBars: {
+      flex: 1,
+      flexDirection: "row",
+      gap: 4,
+    },
+    strengthBar: {
+      flex: 1,
+      height: 4,
+      borderRadius: 2,
+    },
+    criteriaList: {
+      marginTop: 12,
+      gap: 6,
+    },
+    criteriaRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+    },
+    matchRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 6,
+      marginTop: 10,
+    },
+    errorCard: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 8,
+      marginTop: 16,
+      paddingHorizontal: 14,
+      paddingVertical: 10,
+      borderRadius: 10,
+      borderWidth: 1,
+    },
+    errorText: {
+      flex: 1,
+    },
+    primaryButton: {
+      marginTop: 24,
+      paddingVertical: 14,
+      borderRadius: 12,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    primaryButtonText: {
+      fontWeight: "600",
+    },
+    buttonDisabled: {
+      opacity: 0.5,
+    },
+    hint: {
+      textAlign: "center",
+      lineHeight: 18,
+      marginTop: 12,
+      paddingHorizontal: 8,
+    },
+  });
+}

--- a/frontend/app/(tabs)/profile/settings/index.tsx
+++ b/frontend/app/(tabs)/profile/settings/index.tsx
@@ -248,6 +248,14 @@ export default function Settings() {
           <View style={[styles.divider, { backgroundColor: colors.borderLight }]} />
           <Pressable
             style={styles.navRow}
+            onPress={() => router.push("/profile/settings/change-password" as any)}
+          >
+            <Text style={[scaledTypography.body, { color: colors.textPrimary }]}>Change Password</Text>
+            <Ionicons name="chevron-forward" size={18} color={colors.textTertiary} />
+          </Pressable>
+          <View style={[styles.divider, { backgroundColor: colors.borderLight }]} />
+          <Pressable
+            style={styles.navRow}
             onPress={() => router.push("/profile/settings/blocked" as any)}
           >
             <Text style={[scaledTypography.body, { color: colors.textPrimary }]}>Blocked & Muted</Text>

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -55,6 +55,7 @@ export {
   requestDataExport,
   requestEmailChange,
   confirmEmailChange,
+  changePassword,
 } from './profiles';
 export type { UserProfile, SearchUserResult, DataExportResult } from './profiles';
 export { likePost, unlikePost } from './likes';

--- a/frontend/services/api/profiles.ts
+++ b/frontend/services/api/profiles.ts
@@ -196,6 +196,22 @@ export async function confirmEmailChange(
   return response.json();
 }
 
+export async function changePassword(
+  currentPassword: string,
+  newPassword: string
+): Promise<{ message: string }> {
+  const response = await fetch(`${API_BASE_URL}/api/profiles/me/password`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
+    body: JSON.stringify({ currentPassword, newPassword }),
+  });
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || 'Failed to change password');
+  }
+  return response.json();
+}
+
 export async function requestDataExport(): Promise<DataExportResult> {
   const response = await fetch(`${API_BASE_URL}/api/profiles/me/export`, {
     method: 'POST',


### PR DESCRIPTION
Backend:
- Add POST /api/profiles/me/password: validates inputs, verifies current password via Clerk API, updates password via Clerk PATCH, sends confirmation email via nodemailer (fire-and-forget)
- Reuses clerkRequest() and sendEmail() helpers already in profiles.js

Frontend:
- New change-password.tsx: single-screen form with three password fields, live strength indicator (4-bar scale: Weak/Fair/Good/Strong), per-criteria checklist (length, uppercase, number, special char), confirm-field match indicator, and themed error card
- Button disabled until current password filled, length >= 8, and passwords match
- Add changePassword() to API service layer
- Register settings/change-password in profile _layout.tsx
- Add "Change Password" nav entry between "Change Email" and "Blocked & Muted"