### PR TITLE
Fix verify button styling and change email flow

### DIFF
--- a/backend/src/routes/profiles.js
+++ b/backend/src/routes/profiles.js
@@ -326,8 +326,9 @@ router.post('/me/complete-onboarding', requireAuth, async (req, res) => {
 // ── Email Change ───────────────────────────────────────────────────────────────
 
 // POST /api/profiles/me/email/request
-// Step 1: verify current password, add new unverified email to Clerk (triggers
-// verification email via Clerk), send security notification to old address.
+// Verifies the current password and sends a security notification to the old address.
+// Email address creation and verification are handled client-side via Clerk's frontend SDK
+// because prepare_verification / attempt_verification are Frontend API methods only.
 router.post('/me/email/request', requireAuth, async (req, res) => {
   const userId = req.userId;
   const { newEmail, currentPassword } = req.body;
@@ -339,7 +340,7 @@ router.post('/me/email/request', requireAuth, async (req, res) => {
     return res.status(400).json({ error: 'Current password is required.' });
   }
 
-  // 1. Verify current password via Clerk
+  // 1. Verify current password via Clerk Backend API
   let verifyResult;
   try {
     verifyResult = await clerkRequest('POST', `/v1/users/${userId}/verify_password`, { password: currentPassword });
@@ -356,123 +357,25 @@ router.post('/me/email/request', requireAuth, async (req, res) => {
     return res.status(401).json({ error: 'Incorrect password.' });
   }
 
-  // 2. Fetch current email for notification and duplicate check
+  // 2. Duplicate check
   const oldEmail = await getClerkUserEmail(userId);
   const normalizedNew = newEmail.trim().toLowerCase();
   if (oldEmail && oldEmail.toLowerCase() === normalizedNew) {
     return res.status(400).json({ error: 'This is already your current email address.' });
   }
 
-  // 3. Create unverified email address in Clerk
-  let createResult;
-  try {
-    createResult = await clerkRequest('POST', '/v1/email_addresses', {
-      user_id: userId,
-      email_address: normalizedNew,
-      verified: false,
-      primary: false,
-    });
-  } catch (err) {
-    console.error('[EMAIL CHANGE] create email_address error:', err.message);
-    return res.status(500).json({ error: 'Failed to register new email address.' });
-  }
-
-  if (createResult.status !== 200) {
-    const errMsg = createResult.data?.errors?.[0]?.long_message
-      || createResult.data?.errors?.[0]?.message
-      || 'Failed to add email address.';
-    return res.status(400).json({ error: errMsg });
-  }
-
-  const emailAddressId = createResult.data.id;
-
-  // 4. Prepare verification — Clerk sends a 6-digit code to the new address
-  let prepareResult;
-  try {
-    prepareResult = await clerkRequest('POST', `/v1/email_addresses/${emailAddressId}/prepare_verification`, {
-      strategy: 'email_code',
-    });
-  } catch (err) {
-    console.error('[EMAIL CHANGE] prepare_verification error:', err.message);
-    await clerkRequest('DELETE', `/v1/email_addresses/${emailAddressId}`).catch(() => {});
-    return res.status(500).json({ error: 'Failed to send verification email.' });
-  }
-
-  if (prepareResult.status !== 200) {
-    await clerkRequest('DELETE', `/v1/email_addresses/${emailAddressId}`).catch(() => {});
-    return res.status(500).json({ error: 'Failed to send verification email.' });
-  }
-
-  // 5. Security notification to old email (fire-and-forget)
+  // 3. Security notification to old email (fire-and-forget)
   if (oldEmail) {
     sendEmail({
       to: oldEmail,
       subject: 'Security Alert: Email Change Request — BetrFood',
-      text: `Hello,\n\nA request was made to change the email address on your BetrFood account to ${normalizedNew}.\n\nIf you made this request, please verify your new address using the code we sent to ${normalizedNew}.\n\nIf you did not make this request, please contact support immediately.\n\nThe BetrFood Team`,
-      html: `<p>Hello,</p><p>A request was made to change the email address on your BetrFood account to <strong>${normalizedNew}</strong>.</p><p>If you made this request, please verify your new address using the code we sent to <strong>${normalizedNew}</strong>.</p><p>If you did not make this request, please contact support immediately.</p><p>The BetrFood Team</p>`,
+      text: `Hello,\n\nA request was made to change the email address on your BetrFood account to ${normalizedNew}.\n\nIf you made this request, please verify your new address.\n\nIf you did not make this request, please contact support immediately.\n\nThe BetrFood Team`,
+      html: `<p>Hello,</p><p>A request was made to change the email address on your BetrFood account to <strong>${normalizedNew}</strong>.</p><p>If you did not make this request, please contact support immediately.</p><p>The BetrFood Team</p>`,
     }).catch((err) => console.error('[EMAIL CHANGE] Security notification failed:', err.message));
   }
 
-  console.log(`[EMAIL CHANGE] Verification code sent for user ${userId} → ${normalizedNew}`);
-  res.json({ emailAddressId, message: 'Verification code sent to your new email address.' });
-});
-
-// POST /api/profiles/me/email/confirm
-// Step 2: attempt code verification, set new email as primary, remove old addresses.
-router.post('/me/email/confirm', requireAuth, async (req, res) => {
-  const userId = req.userId;
-  const { emailAddressId, code } = req.body;
-
-  if (!emailAddressId || typeof emailAddressId !== 'string') {
-    return res.status(400).json({ error: 'emailAddressId is required.' });
-  }
-  if (!code || typeof code !== 'string' || !code.trim()) {
-    return res.status(400).json({ error: 'Verification code is required.' });
-  }
-
-  // 1. Attempt verification
-  let attemptResult;
-  try {
-    attemptResult = await clerkRequest('POST', `/v1/email_addresses/${emailAddressId}/attempt_verification`, {
-      code: code.trim(),
-    });
-  } catch (err) {
-    console.error('[EMAIL CHANGE] attempt_verification error:', err.message);
-    return res.status(500).json({ error: 'Unable to verify code. Please try again.' });
-  }
-
-  if (attemptResult.status !== 200 || attemptResult.data?.verification?.status !== 'verified') {
-    return res.status(400).json({ error: 'Invalid or expired verification code.' });
-  }
-
-  // 2. Set new address as primary
-  let updateResult;
-  try {
-    updateResult = await clerkRequest('PATCH', `/v1/users/${userId}`, {
-      primary_email_address_id: emailAddressId,
-    });
-  } catch (err) {
-    console.error('[EMAIL CHANGE] set primary error:', err.message);
-    return res.status(500).json({ error: 'Email verified but failed to set as primary. Please contact support.' });
-  }
-
-  if (updateResult.status !== 200) {
-    return res.status(500).json({ error: 'Email verified but failed to set as primary. Please contact support.' });
-  }
-
-  // 3. Remove old email addresses (best-effort)
-  clerkRequest('GET', `/v1/users/${userId}`).then((userResult) => {
-    if (userResult.status !== 200) return;
-    const addresses = userResult.data.email_addresses || [];
-    for (const addr of addresses) {
-      if (addr.id !== emailAddressId) {
-        clerkRequest('DELETE', `/v1/email_addresses/${addr.id}`).catch(() => {});
-      }
-    }
-  }).catch(() => {});
-
-  console.log(`[EMAIL CHANGE] Email updated for user ${userId}`);
-  res.json({ message: 'Email address updated successfully.' });
+  console.log(`[EMAIL CHANGE] Password verified for user ${userId}, client will handle Clerk email flow`);
+  res.json({ message: 'Password verified.' });
 });
 
 // ── Password Change ────────────────────────────────────────────────────────────

--- a/frontend/app/(auth)/signup.tsx
+++ b/frontend/app/(auth)/signup.tsx
@@ -196,15 +196,23 @@ function WebSignup() {
           />
         </View>
         <TouchableOpacity
-          style={styles.signUpButton}
+          style={[styles.signUpButton, loading && { opacity: 0.75 }]}
           onPress={handleVerify}
           disabled={loading}
+          activeOpacity={0.85}
         >
-          {loading ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text style={styles.signUpButtonText}>Verify</Text>
-          )}
+          <LinearGradient
+            colors={["#22C55E", "#10B981"]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.signUpButtonGradient}
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.signUpButtonText}>Verify</Text>
+            )}
+          </LinearGradient>
         </TouchableOpacity>
       </View>
     );
@@ -500,15 +508,23 @@ function NativeSignup() {
         </View>
 
         <TouchableOpacity
-          style={styles.signUpButton}
+          style={[styles.signUpButton, loading && { opacity: 0.75 }]}
           onPress={handleVerify}
           disabled={loading}
+          activeOpacity={0.85}
         >
-          {loading ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text style={styles.signUpButtonText}>Verify</Text>
-          )}
+          <LinearGradient
+            colors={["#22C55E", "#10B981"]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.signUpButtonGradient}
+          >
+            {loading ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.signUpButtonText}>Verify</Text>
+            )}
+          </LinearGradient>
         </TouchableOpacity>
       </View>
     );

--- a/frontend/app/(tabs)/profile/settings/change-email.tsx
+++ b/frontend/app/(tabs)/profile/settings/change-email.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  InputAccessoryView,
   KeyboardAvoidingView,
   Platform,
   Pressable,
@@ -17,7 +18,7 @@ import { router } from "expo-router";
 import { ThemeColors } from "../../../../constants/theme";
 import { useAppTheme } from "../../../../context/ThemeContext";
 import { useScaledTypography } from "../../../../hooks/useScaledTypography";
-import { confirmEmailChange, requestEmailChange } from "../../../../services/api";
+import { requestEmailChange } from "../../../../services/api";
 
 type Step = "request" | "verify";
 
@@ -60,17 +61,31 @@ export default function ChangeEmailScreen() {
       setRequestError("Please enter your current password.");
       return;
     }
+    if (!user) {
+      setRequestError("Not signed in. Please restart the app.");
+      return;
+    }
     setRequesting(true);
     try {
-      const result = await requestEmailChange(newEmail.trim().toLowerCase(), password);
-      setEmailAddressId(result.emailAddressId);
+      // Verify password via backend
+      await requestEmailChange(newEmail.trim().toLowerCase(), password);
+
+      // Create the new email address and send verification code via Clerk frontend SDK
+      const emailAddr = await user.createEmailAddress({ email: newEmail.trim().toLowerCase() });
+      await emailAddr.prepareVerification({ strategy: "email_code" });
+
+      setEmailAddressId(emailAddr.id);
       setStep("verify");
-    } catch (err) {
-      setRequestError(err instanceof Error ? err.message : "Something went wrong.");
+    } catch (err: any) {
+      const msg =
+        err?.errors?.[0]?.longMessage ||
+        err?.errors?.[0]?.message ||
+        (err instanceof Error ? err.message : "Something went wrong.");
+      setRequestError(msg);
     } finally {
       setRequesting(false);
     }
-  }, [newEmail, password]);
+  }, [newEmail, password, user]);
 
   const handleConfirm = useCallback(async () => {
     setConfirmError("");
@@ -78,27 +93,54 @@ export default function ChangeEmailScreen() {
       setConfirmError("Please enter the verification code.");
       return;
     }
+    if (!user) {
+      setConfirmError("Not signed in. Please restart the app.");
+      return;
+    }
     setConfirming(true);
     try {
-      await confirmEmailChange(emailAddressId, code.trim());
+      await user.reload();
+
+      const emailAddr = user.emailAddresses.find((e) => e.id === emailAddressId);
+      if (!emailAddr) throw new Error("Email address not found. Please go back and try again.");
+
+      await emailAddr.attemptVerification({ code: code.trim() });
+      await user.update({ primaryEmailAddressId: emailAddr.id });
+
+      // Remove old email addresses best-effort
+      for (const addr of user.emailAddresses) {
+        if (addr.id !== emailAddr.id) {
+          await addr.destroy().catch(() => {});
+        }
+      }
+
       Alert.alert(
         "Email updated",
         "Your email address has been changed. You may need to sign in again.",
         [{ text: "OK", onPress: () => router.back() }]
       );
-    } catch (err) {
-      setConfirmError(err instanceof Error ? err.message : "Something went wrong.");
+    } catch (err: any) {
+      const msg =
+        err?.errors?.[0]?.longMessage ||
+        err?.errors?.[0]?.message ||
+        (err instanceof Error ? err.message : "Something went wrong.");
+      setConfirmError(msg);
     } finally {
       setConfirming(false);
     }
-  }, [emailAddressId, code]);
+  }, [emailAddressId, code, user]);
 
   const handleBackToRequest = useCallback(() => {
+    // Clean up the pending unverified email address
+    if (emailAddressId && user) {
+      const addr = user.emailAddresses.find((e) => e.id === emailAddressId);
+      addr?.destroy().catch(() => {});
+    }
     setStep("request");
     setCode("");
     setConfirmError("");
     setEmailAddressId("");
-  }, []);
+  }, [emailAddressId, user]);
 
   return (
     <View style={styles.container}>
@@ -224,9 +266,9 @@ export default function ChangeEmailScreen() {
                   placeholder="• • • • • •"
                   placeholderTextColor={colors.placeholder}
                   keyboardType="number-pad"
-                  returnKeyType="done"
                   onSubmitEditing={handleConfirm}
                   maxLength={6}
+                  inputAccessoryViewID={Platform.OS === "ios" ? "change-email-code" : undefined}
                 />
               </View>
 
@@ -260,6 +302,9 @@ export default function ChangeEmailScreen() {
           )}
         </ScrollView>
       </KeyboardAvoidingView>
+      {Platform.OS === "ios" && (
+        <InputAccessoryView nativeID="change-email-code" />
+      )}
     </View>
   );
 }

--- a/frontend/services/api/index.ts
+++ b/frontend/services/api/index.ts
@@ -54,7 +54,6 @@ export {
   searchUsers,
   requestDataExport,
   requestEmailChange,
-  confirmEmailChange,
   changePassword,
 } from './profiles';
 export type { UserProfile, SearchUserResult, DataExportResult } from './profiles';

--- a/frontend/services/api/profiles.ts
+++ b/frontend/services/api/profiles.ts
@@ -167,7 +167,7 @@ export interface DataExportResult {
 export async function requestEmailChange(
   newEmail: string,
   currentPassword: string
-): Promise<{ emailAddressId: string; message: string }> {
+): Promise<{ message: string }> {
   const response = await fetch(`${API_BASE_URL}/api/profiles/me/email/request`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
@@ -176,22 +176,6 @@ export async function requestEmailChange(
   if (!response.ok) {
     const error = await response.json();
     throw new Error(error.error || 'Failed to request email change');
-  }
-  return response.json();
-}
-
-export async function confirmEmailChange(
-  emailAddressId: string,
-  code: string
-): Promise<{ message: string }> {
-  const response = await fetch(`${API_BASE_URL}/api/profiles/me/email/confirm`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', ...(await authHeaders()) },
-    body: JSON.stringify({ emailAddressId, code }),
-  });
-  if (!response.ok) {
-    const error = await response.json();
-    throw new Error(error.error || 'Failed to confirm email change');
   }
   return response.json();
 }


### PR DESCRIPTION
- Fix signup verify button missing LinearGradient (appeared transparent)
- Rewrite change email to use Clerk frontend SDK for email verification since prepare_verification/attempt_verification are Frontend API only
- Backend email/request now only verifies password and sends security alert
- Remove InputAccessoryView "Done" toolbar from code input on iOS